### PR TITLE
Revert "Deprecate Arg::help in favour of Arg::about"

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,24 +222,24 @@ fn main() {
             .short('c')
             .long("config")
             .value_name("FILE")
-            .about("Sets a custom config file")
+            .help("Sets a custom config file")
             .takes_value(true))
         .arg(Arg::new("INPUT")
-            .about("Sets the input file to use")
+            .help("Sets the input file to use")
             .required(true)
             .index(1))
         .arg(Arg::new("v")
             .short('v')
             .multiple_occurrences(true)
             .takes_value(true)
-            .about("Sets the level of verbosity"))
+            .help("Sets the level of verbosity"))
         .subcommand(App::new("test")
             .about("controls testing features")
             .version("1.3")
             .author("Someone E. <someone_else@other.com>")
             .arg(Arg::new("debug")
                 .short('d')
-                .about("print debug information verbosely")))
+                .help("print debug information verbosely")))
         .get_matches();
 
     // You can check the value provided by positional arguments, or option arguments
@@ -321,16 +321,16 @@ args:
         short: c
         long: config
         value_name: FILE
-        about: Sets a custom config file
+        help: Sets a custom config file
         takes_value: true
     - INPUT:
-        about: Sets the input file to use
+        help: Sets the input file to use
         required: true
         index: 1
     - verbose:
         short: v
         multiple_occurrences: true
-        about: Sets the level of verbosity
+        help: Sets the level of verbosity
 subcommands:
     - test:
         about: controls testing features
@@ -340,7 +340,7 @@ subcommands:
             - debug:
                 short: d
                 long: debug
-                about: Print debug information
+                help: Print debug information
 ```
 
 Since this feature requires additional dependencies that not everyone may want, it is *not* compiled in by default and we need to enable a feature flag in Cargo.toml:

--- a/benches/03_complex.rs
+++ b/benches/03_complex.rs
@@ -54,18 +54,18 @@ pub fn build_from_builder(c: &mut Criterion) {
                 .author("Kevin K. <kbknapp@gmail.com>")
                 .arg(
                     Arg::new("opt")
-                        .about("tests options")
+                        .help("tests options")
                         .short('o')
                         .long("option")
                         .setting(ArgSettings::TakesValue)
                         .setting(ArgSettings::MultipleValues)
                         .setting(ArgSettings::MultipleOccurrences),
                 )
-                .arg(Arg::new("positional").about("tests positionals").index(1))
+                .arg(Arg::new("positional").help("tests positionals").index(1))
                 .arg(
                     Arg::new("flag")
                         .short('f')
-                        .about("tests flags")
+                        .help("tests flags")
                         .long("flag")
                         .global(true)
                         .setting(ArgSettings::MultipleOccurrences),
@@ -73,13 +73,13 @@ pub fn build_from_builder(c: &mut Criterion) {
                 .arg(
                     Arg::new("flag2")
                         .short('F')
-                        .about("tests flags with exclusions")
+                        .help("tests flags with exclusions")
                         .conflicts_with("flag")
                         .requires("option2"),
                 )
                 .arg(
                     Arg::new("option2")
-                        .about("tests long options with exclusions")
+                        .help("tests long options with exclusions")
                         .conflicts_with("option")
                         .requires("positional2")
                         .setting(ArgSettings::TakesValue)
@@ -88,14 +88,14 @@ pub fn build_from_builder(c: &mut Criterion) {
                 .arg(
                     Arg::new("positional2")
                         .index(3)
-                        .about("tests positionals with exclusions"),
+                        .help("tests positionals with exclusions"),
                 )
                 .arg(
                     Arg::new("option3")
                         .short('O')
                         .long("Option")
                         .setting(ArgSettings::TakesValue)
-                        .about("tests options with specific value sets")
+                        .help("tests options with specific value sets")
                         .possible_values(OPT3_VALS),
                 )
                 .arg(
@@ -103,14 +103,14 @@ pub fn build_from_builder(c: &mut Criterion) {
                         .setting(ArgSettings::TakesValue)
                         .setting(ArgSettings::MultipleValues)
                         .setting(ArgSettings::MultipleOccurrences)
-                        .about("tests positionals with specific values")
+                        .help("tests positionals with specific values")
                         .index(4)
                         .possible_values(POS3_VALS),
                 )
                 .arg(
                     Arg::new("multvals")
                         .long("multvals")
-                        .about("Tests multiple values, not mult occs")
+                        .help("Tests multiple values, not mult occs")
                         .value_names(&["one", "two"]),
                 )
                 .arg(
@@ -119,7 +119,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                         .setting(ArgSettings::TakesValue)
                         .setting(ArgSettings::MultipleValues)
                         .setting(ArgSettings::MultipleOccurrences)
-                        .about("Tests multiple values, not mult occs")
+                        .help("Tests multiple values, not mult occs")
                         .value_names(&["one", "two"]),
                 )
                 .arg(
@@ -128,7 +128,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                         .setting(ArgSettings::TakesValue)
                         .setting(ArgSettings::MultipleValues)
                         .setting(ArgSettings::MultipleOccurrences)
-                        .about("Tests 2 min vals")
+                        .help("Tests 2 min vals")
                         .min_values(2),
                 )
                 .arg(
@@ -137,7 +137,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                         .setting(ArgSettings::TakesValue)
                         .setting(ArgSettings::MultipleValues)
                         .setting(ArgSettings::MultipleOccurrences)
-                        .about("Tests 3 max vals")
+                        .help("Tests 3 max vals")
                         .max_values(3),
                 )
                 .subcommand(
@@ -152,9 +152,9 @@ pub fn build_from_builder(c: &mut Criterion) {
                                 .setting(ArgSettings::TakesValue)
                                 .setting(ArgSettings::MultipleValues)
                                 .setting(ArgSettings::MultipleOccurrences)
-                                .about("tests options"),
+                                .help("tests options"),
                         )
-                        .arg(Arg::new("scpositional").index(1).about("tests positionals")),
+                        .arg(Arg::new("scpositional").index(1).help("tests positionals")),
                 )
         })
     });

--- a/benches/04_new_help.rs
+++ b/benches/04_new_help.rs
@@ -36,17 +36,17 @@ fn app_example3<'c>() -> App<'c> {
     App::new("MyApp")
         .arg(
             Arg::new("debug")
-                .about("turn on debugging information")
+                .help("turn on debugging information")
                 .short('d'),
         )
         .args(&[
             Arg::new("config")
-                .about("sets the config file to use")
+                .help("sets the config file to use")
                 .setting(ArgSettings::TakesValue)
                 .short('c')
                 .long("config"),
             Arg::new("input")
-                .about("the input file to use")
+                .help("the input file to use")
                 .index(1)
                 .setting(ArgSettings::Required),
         ])
@@ -62,19 +62,19 @@ fn app_example4<'c>() -> App<'c> {
         .author("Kevin K. <kbknapp@gmail.com>")
         .arg(
             Arg::new("debug")
-                .about("turn on debugging information")
+                .help("turn on debugging information")
                 .short('d')
                 .long("debug"),
         )
         .arg(
             Arg::new("config")
-                .about("sets the config file to use")
+                .help("sets the config file to use")
                 .short('c')
                 .long("config"),
         )
         .arg(
             Arg::new("input")
-                .about("the input file to use")
+                .help("the input file to use")
                 .index(1)
                 .setting(ArgSettings::Required),
         )
@@ -83,7 +83,7 @@ fn app_example4<'c>() -> App<'c> {
 fn app_example5<'c>() -> App<'c> {
     App::new("MyApp").arg(
         Arg::new("awesome")
-            .about("turns up the awesome")
+            .help("turns up the awesome")
             .short('a')
             .long("awesome")
             .setting(ArgSettings::MultipleOccurrences)
@@ -96,13 +96,13 @@ fn app_example6<'c>() -> App<'c> {
     App::new("MyApp")
         .arg(
             Arg::new("input")
-                .about("the input file to use")
+                .help("the input file to use")
                 .index(1)
                 .requires("config")
                 .conflicts_with("output")
                 .setting(ArgSettings::Required),
         )
-        .arg(Arg::new("config").about("the config file to use").index(2))
+        .arg(Arg::new("config").help("the config file to use").index(2))
 }
 
 fn app_example7<'c>() -> App<'c> {
@@ -111,7 +111,7 @@ fn app_example7<'c>() -> App<'c> {
         .arg(Arg::new("output"))
         .arg(
             Arg::new("input")
-                .about("the input file to use")
+                .help("the input file to use")
                 .setting(ArgSettings::TakesValue)
                 .setting(ArgSettings::MultipleValues)
                 .setting(ArgSettings::MultipleOccurrences)
@@ -129,7 +129,7 @@ fn app_example8<'c>() -> App<'c> {
         .arg(Arg::new("output"))
         .arg(
             Arg::new("input")
-                .about("the input file to use")
+                .help("the input file to use")
                 .setting(ArgSettings::TakesValue)
                 .setting(ArgSettings::MultipleValues)
                 .setting(ArgSettings::MultipleOccurrences)
@@ -144,7 +144,7 @@ fn app_example8<'c>() -> App<'c> {
 fn app_example10<'c>() -> App<'c> {
     App::new("myapp").about("does awesome things").arg(
         Arg::new("CONFIG")
-            .about("The config file to use (default is \"config.json\")")
+            .help("The config file to use (default is \"config.json\")")
             .short('c')
             .setting(ArgSettings::TakesValue),
     )

--- a/benches/05_ripgrep.rs
+++ b/benches/05_ripgrep.rs
@@ -298,7 +298,7 @@ fn app<F>(_next_line_help: bool, doc: F) -> App<'static>
 where
     F: Fn(&'static str) -> &'static str,
 {
-    let arg = |name| Arg::new(name).about(doc(name));
+    let arg = |name| Arg::new(name).help(doc(name));
     let flag = |name| arg(name).long(name);
 
     App::new("ripgrep")

--- a/benches/06_rustup.rs
+++ b/benches/06_rustup.rs
@@ -30,7 +30,7 @@ fn build_cli() -> App<'static> {
         // .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg(
             Arg::new("verbose")
-                .about("Enable verbose output")
+                .help("Enable verbose output")
                 .short('v')
                 .long("verbose"),
         )
@@ -53,7 +53,7 @@ fn build_cli() -> App<'static> {
                 .arg(Arg::new("toolchain").setting(ArgSettings::Required))
                 .arg(
                     Arg::new("no-self-update")
-                        .about("Don't perform self update when running the `rustup` command")
+                        .help("Don't perform self update when running the `rustup` command")
                         .long("no-self-update")
                         .setting(ArgSettings::Hidden),
                 ),
@@ -223,12 +223,12 @@ fn build_cli() -> App<'static> {
                             Arg::new("path")
                                 .long("path")
                                 .setting(ArgSettings::TakesValue)
-                                .about("Path to the directory"),
+                                .help("Path to the directory"),
                         )
                         .arg(
                             Arg::new("nonexistent")
                                 .long("nonexistent")
-                                .about("Remove override toolchain for all nonexistent directories"),
+                                .help("Remove override toolchain for all nonexistent directories"),
                         ),
                 )
                 .subcommand(
@@ -248,7 +248,7 @@ fn build_cli() -> App<'static> {
                         .arg(
                             Arg::new("nonexistent")
                                 .long("nonexistent")
-                                .about("Remove override toolchain for all nonexistent directories"),
+                                .help("Remove override toolchain for all nonexistent directories"),
                         ),
                 ),
         )
@@ -278,12 +278,12 @@ fn build_cli() -> App<'static> {
                 .arg(
                     Arg::new("book")
                         .long("book")
-                        .about("The Rust Programming Language book"),
+                        .help("The Rust Programming Language book"),
                 )
                 .arg(
                     Arg::new("std")
                         .long("std")
-                        .about("Standard library API documentation"),
+                        .help("Standard library API documentation"),
                 )
                 .group(ArgGroup::new("page").args(&["book", "std"])),
         )

--- a/clap_derive/examples/doc_comments.rs
+++ b/clap_derive/examples/doc_comments.rs
@@ -37,7 +37,7 @@ struct Opt {
     #[clap(
         short,
         long,
-        long_about = r"This is a raw string.
+        long_help = r"This is a raw string.
 
 It can be used to pass well formatted content (e.g. lists or source
 code) in the description:

--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -591,7 +591,7 @@ impl Attrs {
             env_casing,
         );
         res.push_attrs(&variant.attrs);
-        res.push_doc_comment(&variant.attrs, "about");
+        res.push_doc_comment(&variant.attrs, "help");
 
         if res.has_custom_parser {
             abort!(
@@ -626,7 +626,7 @@ impl Attrs {
             env_casing,
         );
         res.push_attrs(&field.attrs);
-        res.push_doc_comment(&field.attrs, "about");
+        res.push_doc_comment(&field.attrs, "help");
 
         match &*res.kind {
             Kind::Flatten => {
@@ -794,10 +794,10 @@ impl Attrs {
     }
 
     /// generate methods on top of a field
-    pub fn field_methods(&self, supports_long_about: bool) -> proc_macro2::TokenStream {
+    pub fn field_methods(&self, supports_long_help: bool) -> proc_macro2::TokenStream {
         let methods = &self.methods;
         let help_heading = self.help_heading.as_ref().into_iter();
-        match supports_long_about {
+        match supports_long_help {
             true => {
                 let doc_comment = &self.doc_comment;
                 quote!( #(#doc_comment)* #(#help_heading)* #(#methods)* )
@@ -806,7 +806,7 @@ impl Attrs {
                 let doc_comment = self
                     .doc_comment
                     .iter()
-                    .filter(|mth| mth.name != "long_about");
+                    .filter(|mth| mth.name != "long_help");
                 quote!( #(#doc_comment)* #(#help_heading)* #(#methods)* )
             }
         }
@@ -864,7 +864,7 @@ impl Attrs {
     pub fn has_explicit_methods(&self) -> bool {
         self.methods
             .iter()
-            .any(|m| m.name != "about" && m.name != "long_about")
+            .any(|m| m.name != "help" && m.name != "long_help")
     }
 }
 

--- a/clap_derive/tests/doc-comments-help.rs
+++ b/clap_derive/tests/doc-comments-help.rs
@@ -40,7 +40,7 @@ fn help_is_better_than_comments() {
     #[clap(name = "lorem-ipsum", about = "Dolor sit amet")]
     struct LoremIpsum {
         /// Fooify a bar
-        #[clap(short, long, about = "DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES")]
+        #[clap(short, long, help = "DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES")]
         foo: bool,
     }
 
@@ -107,7 +107,7 @@ fn top_long_doc_comment_both_help_long_help() {
         ///
         /// Or something else
         Foo {
-            #[clap(about = "foo")]
+            #[clap(help = "foo")]
             bars: String,
         },
     }

--- a/clap_derive/tests/skip.rs
+++ b/clap_derive/tests/skip.rs
@@ -103,10 +103,10 @@ fn skip_enum() {
 fn skip_help_doc_comments() {
     #[derive(Parser, Debug, PartialEq)]
     pub struct Opt {
-        #[clap(skip, about = "internal_stuff")]
+        #[clap(skip, help = "internal_stuff")]
         a: u32,
 
-        #[clap(skip, long_about = "internal_stuff\ndo not touch")]
+        #[clap(skip, long_help = "internal_stuff\ndo not touch")]
         b: u32,
 
         /// Not meant to be used by clap.

--- a/clap_generate/src/generators/shells/elvish.rs
+++ b/clap_generate/src/generators/shells/elvish.rs
@@ -84,7 +84,7 @@ fn generate_inner<'help>(
 
     for option in p.get_opts() {
         if let Some(shorts) = option.get_short_and_visible_aliases() {
-            let tooltip = get_tooltip(option.get_about(), shorts[0]);
+            let tooltip = get_tooltip(option.get_help(), shorts[0]);
             for short in shorts {
                 completions.push_str(&preamble);
                 completions.push_str(format!("-{} '{}'", short, tooltip).as_str());
@@ -92,7 +92,7 @@ fn generate_inner<'help>(
         }
 
         if let Some(longs) = option.get_long_and_visible_aliases() {
-            let tooltip = get_tooltip(option.get_about(), longs[0]);
+            let tooltip = get_tooltip(option.get_help(), longs[0]);
             for long in longs {
                 completions.push_str(&preamble);
                 completions.push_str(format!("--{} '{}'", long, tooltip).as_str());
@@ -102,7 +102,7 @@ fn generate_inner<'help>(
 
     for flag in utils::flags(p) {
         if let Some(shorts) = flag.get_short_and_visible_aliases() {
-            let tooltip = get_tooltip(flag.get_about(), shorts[0]);
+            let tooltip = get_tooltip(flag.get_help(), shorts[0]);
             for short in shorts {
                 completions.push_str(&preamble);
                 completions.push_str(format!("-{} '{}'", short, tooltip).as_str());
@@ -110,7 +110,7 @@ fn generate_inner<'help>(
         }
 
         if let Some(longs) = flag.get_long_and_visible_aliases() {
-            let tooltip = get_tooltip(flag.get_about(), longs[0]);
+            let tooltip = get_tooltip(flag.get_help(), longs[0]);
             for long in longs {
                 completions.push_str(&preamble);
                 completions.push_str(format!("--{} '{}'", long, tooltip).as_str());

--- a/clap_generate/src/generators/shells/fish.rs
+++ b/clap_generate/src/generators/shells/fish.rs
@@ -87,7 +87,7 @@ fn gen_fish_inner(root_command: &str, parent_commands: &[&str], app: &App, buffe
             }
         }
 
-        if let Some(data) = option.get_about() {
+        if let Some(data) = option.get_help() {
             template.push_str(format!(" -d '{}'", escape_string(data)).as_str());
         }
 
@@ -112,7 +112,7 @@ fn gen_fish_inner(root_command: &str, parent_commands: &[&str], app: &App, buffe
             }
         }
 
-        if let Some(data) = flag.get_about() {
+        if let Some(data) = flag.get_help() {
             template.push_str(format!(" -d '{}'", escape_string(data)).as_str());
         }
 
@@ -159,7 +159,7 @@ fn value_completion(option: &Arg) -> String {
                     Some(format!(
                         "{}\t{}",
                         value.get_name(),
-                        value.get_about().unwrap_or_default()
+                        value.get_help().unwrap_or_default()
                     ))
                 })
                 .collect::<Vec<_>>()

--- a/clap_generate/src/generators/shells/powershell.rs
+++ b/clap_generate/src/generators/shells/powershell.rs
@@ -88,7 +88,7 @@ fn generate_inner<'help>(
 
     for option in p.get_opts() {
         if let Some(shorts) = option.get_short_and_visible_aliases() {
-            let tooltip = get_tooltip(option.get_about(), shorts[0]);
+            let tooltip = get_tooltip(option.get_help(), shorts[0]);
             for short in shorts {
                 completions.push_str(&preamble);
                 completions.push_str(
@@ -102,7 +102,7 @@ fn generate_inner<'help>(
         }
 
         if let Some(longs) = option.get_long_and_visible_aliases() {
-            let tooltip = get_tooltip(option.get_about(), longs[0]);
+            let tooltip = get_tooltip(option.get_help(), longs[0]);
             for long in longs {
                 completions.push_str(&preamble);
                 completions.push_str(
@@ -118,7 +118,7 @@ fn generate_inner<'help>(
 
     for flag in utils::flags(p) {
         if let Some(shorts) = flag.get_short_and_visible_aliases() {
-            let tooltip = get_tooltip(flag.get_about(), shorts[0]);
+            let tooltip = get_tooltip(flag.get_help(), shorts[0]);
             for short in shorts {
                 completions.push_str(&preamble);
                 completions.push_str(
@@ -132,7 +132,7 @@ fn generate_inner<'help>(
         }
 
         if let Some(longs) = flag.get_long_and_visible_aliases() {
-            let tooltip = get_tooltip(flag.get_about(), longs[0]);
+            let tooltip = get_tooltip(flag.get_help(), longs[0]);
             for long in longs {
                 completions.push_str(&preamble);
                 completions.push_str(

--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -347,7 +347,7 @@ fn value_completion(arg: &Arg) -> Option<String> {
     if let Some(values) = &arg.get_possible_values() {
         if values
             .iter()
-            .any(|value| !value.is_hidden() && value.get_about().is_some())
+            .any(|value| !value.is_hidden() && value.get_help().is_some())
         {
             Some(format!(
                 "(({}))",
@@ -358,9 +358,9 @@ fn value_completion(arg: &Arg) -> Option<String> {
                             None
                         } else {
                             Some(format!(
-                                r#"{name}\:"{about}""#,
+                                r#"{name}\:"{tooltip}""#,
                                 name = escape_value(value.get_name()),
-                                about = value.get_about().map(escape_help).unwrap_or_default()
+                                tooltip = value.get_help().map(escape_help).unwrap_or_default()
                             ))
                         }
                     })
@@ -429,7 +429,7 @@ fn write_opts_of(p: &App, p_global: Option<&App>) -> String {
     for o in p.get_opts() {
         debug!("write_opts_of:iter: o={}", o.get_name());
 
-        let help = o.get_about().map_or(String::new(), escape_help);
+        let help = o.get_help().map_or(String::new(), escape_help);
         let conflicts = arg_conflicts(p, o, p_global);
 
         let multiple = if o.is_set(ArgSettings::MultipleOccurrences) {
@@ -532,7 +532,7 @@ fn write_flags_of(p: &App, p_global: Option<&App>) -> String {
     for f in utils::flags(p) {
         debug!("write_flags_of:iter: f={}", f.get_name());
 
-        let help = f.get_about().map_or(String::new(), escape_help);
+        let help = f.get_help().map_or(String::new(), escape_help);
         let conflicts = arg_conflicts(p, &f, p_global);
 
         let multiple = if f.is_set(ArgSettings::MultipleOccurrences) {
@@ -628,7 +628,7 @@ fn write_positionals_of(p: &App) -> String {
             cardinality = cardinality,
             name = arg.get_name(),
             help = arg
-                .get_about()
+                .get_help()
                 .map_or("".to_owned(), |v| " -- ".to_owned() + v)
                 .replace("[", "\\[")
                 .replace("]", "\\]")

--- a/clap_generate/tests/completions/bash.rs
+++ b/clap_generate/tests/completions/bash.rs
@@ -12,7 +12,7 @@ fn build_app_with_name(s: &'static str) -> App<'static> {
         .arg(
             Arg::new("file")
                 .value_hint(ValueHint::FilePath)
-                .about("some input file"),
+                .help("some input file"),
         )
         .arg(Arg::new("choice").possible_values(["first", "second"]))
         .subcommand(
@@ -20,7 +20,7 @@ fn build_app_with_name(s: &'static str) -> App<'static> {
                 Arg::new("case")
                     .long("case")
                     .takes_value(true)
-                    .about("the case to test"),
+                    .help("the case to test"),
             ),
         )
 }
@@ -122,7 +122,7 @@ fn build_app_special_commands() -> App<'static> {
                 Arg::new("config")
                     .long("--config")
                     .takes_value(true)
-                    .about("the other case to test"),
+                    .help("the other case to test"),
             ),
         )
         .subcommand(App::new("some-cmd-with-hyphens").alias("hyphen"))
@@ -260,7 +260,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('F')
                 .long("flag")
                 .visible_alias("flg")
-                .about("cmd flag"),
+                .help("cmd flag"),
         )
         .arg(
             Arg::new("option")
@@ -268,7 +268,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('O')
                 .long("option")
                 .visible_alias("opt")
-                .about("cmd option")
+                .help("cmd option")
                 .takes_value(true),
         )
         .arg(Arg::new("positional"))

--- a/clap_generate/tests/completions/elvish.rs
+++ b/clap_generate/tests/completions/elvish.rs
@@ -12,14 +12,14 @@ fn build_app_with_name(s: &'static str) -> App<'static> {
         .arg(
             Arg::new("file")
                 .value_hint(ValueHint::FilePath)
-                .about("some input file"),
+                .help("some input file"),
         )
         .subcommand(
             App::new("test").about("tests things").arg(
                 Arg::new("case")
                     .long("case")
                     .takes_value(true)
-                    .about("the case to test"),
+                    .help("the case to test"),
             ),
         )
 }
@@ -86,7 +86,7 @@ fn build_app_special_commands() -> App<'static> {
                 Arg::new("config")
                     .long("--config")
                     .takes_value(true)
-                    .about("the other case to test"),
+                    .help("the other case to test"),
             ),
         )
         .subcommand(App::new("some-cmd-with-hyphens").alias("hyphen"))
@@ -166,7 +166,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('F')
                 .long("flag")
                 .visible_alias("flg")
-                .about("cmd flag"),
+                .help("cmd flag"),
         )
         .arg(
             Arg::new("option")
@@ -174,7 +174,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('O')
                 .long("option")
                 .visible_alias("opt")
-                .about("cmd option")
+                .help("cmd option")
                 .takes_value(true),
         )
         .arg(Arg::new("positional"))

--- a/clap_generate/tests/completions/fish.rs
+++ b/clap_generate/tests/completions/fish.rs
@@ -12,14 +12,14 @@ fn build_app_with_name(s: &'static str) -> App<'static> {
         .arg(
             Arg::new("file")
                 .value_hint(ValueHint::FilePath)
-                .about("some input file"),
+                .help("some input file"),
         )
         .subcommand(
             App::new("test").about("tests things").arg(
                 Arg::new("case")
                     .long("case")
                     .takes_value(true)
-                    .about("the case to test"),
+                    .help("the case to test"),
             ),
         )
 }
@@ -53,7 +53,7 @@ fn build_app_special_commands() -> App<'static> {
                 Arg::new("config")
                     .long("--config")
                     .takes_value(true)
-                    .about("the other case to test"),
+                    .help("the other case to test"),
             ),
         )
         .subcommand(App::new("some-cmd-with-hyphens").alias("hyphen"))
@@ -88,28 +88,28 @@ fn build_app_special_help() -> App<'static> {
         .arg(
             Arg::new("single-quotes")
                 .long("single-quotes")
-                .about("Can be 'always', 'auto', or 'never'"),
+                .help("Can be 'always', 'auto', or 'never'"),
         )
         .arg(
             Arg::new("double-quotes")
                 .long("double-quotes")
-                .about("Can be \"always\", \"auto\", or \"never\""),
+                .help("Can be \"always\", \"auto\", or \"never\""),
         )
         .arg(
             Arg::new("backticks")
                 .long("backticks")
-                .about("For more information see `echo test`"),
+                .help("For more information see `echo test`"),
         )
-        .arg(Arg::new("backslash").long("backslash").about("Avoid '\\n'"))
+        .arg(Arg::new("backslash").long("backslash").help("Avoid '\\n'"))
         .arg(
             Arg::new("brackets")
                 .long("brackets")
-                .about("List packages [filter]"),
+                .help("List packages [filter]"),
         )
         .arg(
             Arg::new("expansions")
                 .long("expansions")
-                .about("Execute the shell command with $SHELL"),
+                .help("Execute the shell command with $SHELL"),
         )
 }
 
@@ -139,7 +139,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('F')
                 .long("flag")
                 .visible_alias("flg")
-                .about("cmd flag"),
+                .help("cmd flag"),
         )
         .arg(
             Arg::new("option")
@@ -147,7 +147,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('O')
                 .long("option")
                 .visible_alias("opt")
-                .about("cmd option")
+                .help("cmd option")
                 .takes_value(true),
         )
         .arg(Arg::new("positional"))
@@ -174,7 +174,7 @@ fn build_app_sub_subcommands() -> App<'static> {
                     Arg::new("config")
                         .long("--config")
                         .takes_value(true)
-                        .about("the other case to test"),
+                        .help("the other case to test"),
                 ),
             ),
     )

--- a/clap_generate/tests/completions/powershell.rs
+++ b/clap_generate/tests/completions/powershell.rs
@@ -12,11 +12,11 @@ fn build_app_with_name(s: &'static str) -> App<'static> {
         .arg(
             Arg::new("file")
                 .value_hint(ValueHint::FilePath)
-                .about("some input file"),
+                .help("some input file"),
         )
         .arg(
             Arg::new("config")
-                .about("some config file")
+                .help("some config file")
                 .short('c')
                 .visible_short_alias('C')
                 .long("config")
@@ -27,7 +27,7 @@ fn build_app_with_name(s: &'static str) -> App<'static> {
                 Arg::new("case")
                     .long("case")
                     .takes_value(true)
-                    .about("the case to test"),
+                    .help("the case to test"),
             ),
         )
 }
@@ -105,7 +105,7 @@ fn build_app_special_commands() -> App<'static> {
                 Arg::new("config")
                     .long("--config")
                     .takes_value(true)
-                    .about("the other case to test"),
+                    .help("the other case to test"),
             ),
         )
         .subcommand(App::new("some-cmd-with-hyphens").alias("hyphen"))
@@ -198,7 +198,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('F')
                 .long("flag")
                 .visible_alias("flg")
-                .about("cmd flag"),
+                .help("cmd flag"),
         )
         .arg(
             Arg::new("option")
@@ -206,7 +206,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('O')
                 .long("option")
                 .visible_alias("opt")
-                .about("cmd option")
+                .help("cmd option")
                 .takes_value(true),
         )
         .arg(Arg::new("positional"))

--- a/clap_generate/tests/completions/zsh.rs
+++ b/clap_generate/tests/completions/zsh.rs
@@ -12,14 +12,14 @@ fn build_app_with_name(s: &'static str) -> App<'static> {
         .arg(
             Arg::new("file")
                 .value_hint(ValueHint::FilePath)
-                .about("some input file"),
+                .help("some input file"),
         )
         .subcommand(
             App::new("test").about("tests things").arg(
                 Arg::new("case")
                     .long("case")
                     .takes_value(true)
-                    .about("the case to test"),
+                    .help("the case to test"),
             ),
         )
 }
@@ -115,7 +115,7 @@ fn build_app_special_commands() -> App<'static> {
                 Arg::new("config")
                     .long("--config")
                     .takes_value(true)
-                    .about("the other case to test"),
+                    .help("the other case to test"),
             ),
         )
         .subcommand(App::new("some-cmd-with-hypens").alias("hyphen"))
@@ -252,28 +252,28 @@ fn build_app_special_help() -> App<'static> {
         .arg(
             Arg::new("single-quotes")
                 .long("single-quotes")
-                .about("Can be 'always', 'auto', or 'never'"),
+                .help("Can be 'always', 'auto', or 'never'"),
         )
         .arg(
             Arg::new("double-quotes")
                 .long("double-quotes")
-                .about("Can be \"always\", \"auto\", or \"never\""),
+                .help("Can be \"always\", \"auto\", or \"never\""),
         )
         .arg(
             Arg::new("backticks")
                 .long("backticks")
-                .about("For more information see `echo test`"),
+                .help("For more information see `echo test`"),
         )
-        .arg(Arg::new("backslash").long("backslash").about("Avoid '\\n'"))
+        .arg(Arg::new("backslash").long("backslash").help("Avoid '\\n'"))
         .arg(
             Arg::new("brackets")
                 .long("brackets")
-                .about("List packages [filter]"),
+                .help("List packages [filter]"),
         )
         .arg(
             Arg::new("expansions")
                 .long("expansions")
-                .about("Execute the shell command with $SHELL"),
+                .help("Execute the shell command with $SHELL"),
         )
 }
 
@@ -450,7 +450,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('F')
                 .long("flag")
                 .visible_alias("flg")
-                .about("cmd flag"),
+                .help("cmd flag"),
         )
         .arg(
             Arg::new("option")
@@ -458,7 +458,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('O')
                 .long("option")
                 .visible_alias("opt")
-                .about("cmd option")
+                .help("cmd option")
                 .takes_value(true),
         )
         .arg(Arg::new("positional"))
@@ -518,7 +518,7 @@ fn build_app_with_files_and_dirs() -> App<'static> {
         .arg(
             Arg::new("directory")
                 .long("dir")
-                .about("specify a directory")
+                .help("specify a directory")
                 .value_name("DIR")
                 .number_of_values(3)
                 .value_hint(ValueHint::DirPath),
@@ -528,7 +528,7 @@ fn build_app_with_files_and_dirs() -> App<'static> {
                 .long("inputfiles")
                 .value_name("FILE")
                 .multiple_occurrences(true)
-                .about("specify a file")
+                .help("specify a file")
                 .value_hint(ValueHint::FilePath),
         )
 }

--- a/clap_generate_fig/src/fig.rs
+++ b/clap_generate_fig/src/fig.rs
@@ -144,7 +144,7 @@ fn gen_options(app: &App, indent: usize) -> String {
             ));
         }
 
-        if let Some(data) = option.get_about() {
+        if let Some(data) = option.get_help() {
             buffer.push_str(&format!(
                 "{:indent$}description: \"{}\",\n",
                 "",
@@ -194,7 +194,7 @@ fn gen_options(app: &App, indent: usize) -> String {
             ));
         }
 
-        if let Some(data) = flag.get_about() {
+        if let Some(data) = flag.get_help() {
             buffer.push_str(&format!(
                 "{:indent$}description: \"{}\",\n",
                 "",
@@ -257,11 +257,11 @@ fn gen_args(arg: &Arg, indent: usize) -> String {
                 indent = indent + 4,
             ));
 
-            if let Some(about) = value.get_about() {
+            if let Some(help) = value.get_help() {
                 buffer.push_str(&format!(
                     "{:indent$}description: \"{}\",\n",
                     "",
-                    escape_string(about),
+                    escape_string(help),
                     indent = indent + 4
                 ));
             }

--- a/clap_generate_fig/tests/completions/fig.rs
+++ b/clap_generate_fig/tests/completions/fig.rs
@@ -13,14 +13,14 @@ fn build_app_with_name(s: &'static str) -> App<'static> {
         .arg(
             Arg::new("file")
                 .value_hint(ValueHint::FilePath)
-                .about("some input file"),
+                .help("some input file"),
         )
         .subcommand(
             App::new("test").about("tests things").arg(
                 Arg::new("case")
                     .long("case")
                     .takes_value(true)
-                    .about("the case to test"),
+                    .help("the case to test"),
             ),
         )
 }
@@ -101,7 +101,7 @@ fn build_app_special_commands() -> App<'static> {
                 Arg::new("config")
                     .long("--config")
                     .takes_value(true)
-                    .about("the other case to test"),
+                    .help("the other case to test"),
             ),
         )
         .subcommand(App::new("some-cmd-with-hyphens").alias("hyphen"))
@@ -211,28 +211,28 @@ fn build_app_special_help() -> App<'static> {
         .arg(
             Arg::new("single-quotes")
                 .long("single-quotes")
-                .about("Can be 'always', 'auto', or 'never'"),
+                .help("Can be 'always', 'auto', or 'never'"),
         )
         .arg(
             Arg::new("double-quotes")
                 .long("double-quotes")
-                .about("Can be \"always\", \"auto\", or \"never\""),
+                .help("Can be \"always\", \"auto\", or \"never\""),
         )
         .arg(
             Arg::new("backticks")
                 .long("backticks")
-                .about("For more information see `echo test`"),
+                .help("For more information see `echo test`"),
         )
-        .arg(Arg::new("backslash").long("backslash").about("Avoid '\\n'"))
+        .arg(Arg::new("backslash").long("backslash").help("Avoid '\\n'"))
         .arg(
             Arg::new("brackets")
                 .long("brackets")
-                .about("List packages [filter]"),
+                .help("List packages [filter]"),
         )
         .arg(
             Arg::new("expansions")
                 .long("expansions")
-                .about("Execute the shell command with $SHELL"),
+                .help("Execute the shell command with $SHELL"),
         )
 }
 
@@ -294,7 +294,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('F')
                 .long("flag")
                 .visible_alias("flg")
-                .about("cmd flag"),
+                .help("cmd flag"),
         )
         .arg(
             Arg::new("option")
@@ -302,7 +302,7 @@ fn build_app_with_aliases() -> App<'static> {
                 .visible_short_alias('O')
                 .long("option")
                 .visible_alias("opt")
-                .about("cmd option")
+                .help("cmd option")
                 .takes_value(true),
         )
         .arg(Arg::new("positional"))
@@ -357,7 +357,7 @@ fn build_app_sub_subcommands() -> App<'static> {
                     Arg::new("config")
                         .long("--config")
                         .takes_value(true)
-                        .about("the other case to test"),
+                        .help("the other case to test"),
                 ),
             ),
     )

--- a/examples/01b_quick_example.rs
+++ b/examples/01b_quick_example.rs
@@ -40,12 +40,12 @@ fn main() {
                 .short('c')
                 .long("config")
                 .value_name("FILE")
-                .about("Sets a custom config file")
+                .help("Sets a custom config file")
                 .takes_value(true),
         )
         .arg(
             Arg::new("output")
-                .about("Sets an optional output file")
+                .help("Sets an optional output file")
                 .index(1),
         )
         .arg(
@@ -53,12 +53,12 @@ fn main() {
                 .short('d')
                 .long("debug")
                 .multiple_occurrences(true)
-                .about("Turn debugging information on"),
+                .help("Turn debugging information on"),
         )
         .subcommand(
             App::new("test")
                 .about("does testing things")
-                .arg(Arg::new("list").short('l').about("lists test values")),
+                .arg(Arg::new("list").short('l').help("lists test values")),
         )
         .get_matches();
 

--- a/examples/03_args.rs
+++ b/examples/03_args.rs
@@ -28,19 +28,19 @@ fn main() {
         // A simple "Flag" argument example (i.e. "-d") using the builder pattern
         .arg(
             Arg::new("debug")
-                .about("turn on debugging information")
+                .help("turn on debugging information")
                 .short('d'),
         )
         // Two arguments, one "Option" argument (i.e. one that takes a value) such
         // as "-c some", and one positional argument (i.e. "myapp some_file")
         .args(&[
             Arg::new("config")
-                .about("sets the config file to use")
+                .help("sets the config file to use")
                 .takes_value(true)
                 .short('c')
                 .long("config"),
             Arg::new("input")
-                .about("the input file to use")
+                .help("the input file to use")
                 .required(true),
         ])
         // *Note* the following two examples are convenience methods, if you wish

--- a/examples/04_using_matches.rs
+++ b/examples/04_using_matches.rs
@@ -20,20 +20,20 @@ fn main() {
         .author("Kevin K. <kbknapp@gmail.com>")
         .arg(
             Arg::new("debug")
-                .about("turn on debugging information")
+                .help("turn on debugging information")
                 .short('d')
                 .long("debug"),
         )
         .arg(
             Arg::new("config")
-                .about("sets the config file to use")
+                .help("sets the config file to use")
                 .short('c')
                 .long("config")
                 .takes_value(true),
         )
         .arg(
             Arg::new("input")
-                .about("the input file to use")
+                .help("the input file to use")
                 .index(1)
                 .required(true),
         )

--- a/examples/05_flag_args.rs
+++ b/examples/05_flag_args.rs
@@ -15,7 +15,7 @@ fn main() {
         // you want for your individual case.
         .arg(
             Arg::new("awesome")
-                .about("turns up the awesome") // Displayed when showing help info
+                .help("turns up the awesome") // Displayed when showing help info
                 .short('a') // Trigger this arg with "-a"
                 .long("awesome") // Trigger this arg with "--awesome"
                 .multiple_occurrences(true) // This flag should allow multiple

--- a/examples/06_positional_args.rs
+++ b/examples/06_positional_args.rs
@@ -13,7 +13,7 @@ fn main() {
         // ones that apply to your individual case.
         .arg(
             Arg::new("input")
-                .about("the input file to use") // Displayed when showing help info
+                .help("the input file to use") // Displayed when showing help info
                 .index(1) // Set the order in which the user must
                 // specify this argument (Starts at 1)
                 .requires("config") // Says, "If the user uses "input", they MUST
@@ -24,7 +24,7 @@ fn main() {
                                  // NOTE: mutual exclusions take precedence over
                                  // required arguments
         )
-        .arg(Arg::new("config").about("the config file to use").index(2)) // Note, we do not need to specify required(true)
+        .arg(Arg::new("config").help("the config file to use").index(2)) // Note, we do not need to specify required(true)
         // if we don't want to, because "input" already
         // requires "config"
         // Note, we also do not need to specify requires("input")

--- a/examples/07_option_args.rs
+++ b/examples/07_option_args.rs
@@ -15,7 +15,7 @@ fn main() {
         // to your particular case.
         .arg(
             Arg::new("input")
-                .about("the input file to use") // Displayed when showing help info
+                .help("the input file to use") // Displayed when showing help info
                 .takes_value(true) // MUST be set to true in order to be an "option" argument
                 .short('i') // This argument is triggered with "-i"
                 .long("input") // This argument is triggered with "--input"

--- a/examples/08_subcommands.rs
+++ b/examples/08_subcommands.rs
@@ -28,7 +28,7 @@ fn main() {
                 .author("Kevin K.") // And authors
                 .arg(
                     Arg::new("input") // And their own arguments
-                        .about("the file to add")
+                        .help("the file to add")
                         .index(1)
                         .required(true),
                 ),

--- a/examples/10_default_values.rs
+++ b/examples/10_default_values.rs
@@ -11,14 +11,14 @@ fn main() {
         .about("does awesome things")
         .arg(
             Arg::new("INPUT")
-                .about("The input file to use")
+                .help("The input file to use")
                 .default_value("input.txt")
                 .index(1),
         )
         // Next we'll use the Option::unwrap_or method on this "CONFIG" option
         .arg(
             Arg::new("CONFIG")
-                .about("The config file to use")
+                .help("The config file to use")
                 .short('c')
                 .takes_value(true),
         )

--- a/examples/11_only_specific_values.rs
+++ b/examples/11_only_specific_values.rs
@@ -14,7 +14,7 @@ fn main() {
         .about("does awesome things")
         .arg(
             Arg::new("MODE")
-                .about("What mode to run the program in")
+                .help("What mode to run the program in")
                 .index(1)
                 .possible_values(["fast", "slow"])
                 .required(true),

--- a/examples/15_custom_validator.rs
+++ b/examples/15_custom_validator.rs
@@ -9,7 +9,7 @@ fn main() {
         // Application logic goes here...
         .arg(
             Arg::new("input")
-                .about("the input file to use")
+                .help("the input file to use")
                 .index(1)
                 .required(true)
                 // You can pass in a closure, or a function

--- a/examples/17_yaml.yaml
+++ b/examples/17_yaml.yaml
@@ -13,20 +13,20 @@ args:
     # The name of this argument, is 'opt' which will be used to access the value
     # later in your Rust code
     - opt:
-        about: example option argument from yaml
+        help: example option argument from yaml
         short: o
         long: option
         multiple_occurrences: true
         takes_value: true
     - pos:
-        about: example positional argument from yaml
+        help: example positional argument from yaml
         index: 1
         # A list of possible values can be defined as a list
         possible_values:
             - fast
             - slow
     - flag:
-        about: demo flag argument
+        help: demo flag argument
         short: F
         multiple_occurrences: true
         takes_value: true
@@ -39,13 +39,13 @@ args:
             - pos
     - mode:
         long: mode
-        about: shows an option with specific values
+        help: shows an option with specific values
         # possible_values can also be defined in this list format
         possible_values: [ vi, emacs ]
         takes_value: true
     - mvals:
         long: mult-vals
-        about: demos an option which has two named values
+        help: demos an option which has two named values
         # value names can be described in a list, where the help will be shown
         # --mult-vals <one> <two>
         value_names:
@@ -54,12 +54,12 @@ args:
     - minvals:
         long: min-vals
         multiple_values: true
-        about: you must supply at least two values to satisfy me
+        help: you must supply at least two values to satisfy me
         min_values: 2
     - maxvals:
         long: max-vals
         multiple_values: true
-        about: you can only supply a max of 3 values for me!
+        help: you can only supply a max of 3 values for me!
         max_values: 3
 
 # All subcommands must be listed in the 'subcommand:' object, where the key to
@@ -77,10 +77,10 @@ subcommands:
             - scopt:
                 short: B
                 multiple_occurrences: true
-                about: example subcommand option
+                help: example subcommand option
                 takes_value: true
             - scpos1:
-                about: example subcommand positional
+                help: example subcommand positional
                 index: 1
 
 # ArgGroups are supported as well, and must be specified in the 'groups:'

--- a/examples/21_aliases.rs
+++ b/examples/21_aliases.rs
@@ -10,7 +10,7 @@ fn main() {
                 .author("Kevin K.")
                 .arg(
                     Arg::new("input")
-                        .about("the file to add")
+                        .help("the file to add")
                         .index(1)
                         .required(true),
                 ),

--- a/examples/23_flag_subcommands_pacman.rs
+++ b/examples/23_flag_subcommands_pacman.rs
@@ -38,7 +38,7 @@ fn main() {
                     Arg::new("search")
                         .short('s')
                         .long("search")
-                        .about("search locally installed packages for matching strings")
+                        .help("search locally installed packages for matching strings")
                         .conflicts_with("info")
                         .takes_value(true)
                         .multiple_values(true),
@@ -48,7 +48,7 @@ fn main() {
                         .long("info")
                         .short('i')
                         .conflicts_with("search")
-                        .about("view package information")
+                        .help("view package information")
                         .takes_value(true)
                         .multiple_values(true),
                 ),
@@ -68,18 +68,18 @@ fn main() {
                         .conflicts_with("info")
                         .takes_value(true)
                         .multiple_values(true)
-                        .about("search remote repositories for matching strings"),
+                        .help("search remote repositories for matching strings"),
                 )
                 .arg(
                     Arg::new("info")
                         .long("info")
                         .conflicts_with("search")
                         .short('i')
-                        .about("view package information"),
+                        .help("view package information"),
                 )
                 .arg(
                     Arg::new("package")
-                        .about("packages")
+                        .help("packages")
                         .required_unless_present("search")
                         .takes_value(true)
                         .multiple_values(true),

--- a/examples/24a_multicall_busybox.rs
+++ b/examples/24a_multicall_busybox.rs
@@ -17,7 +17,7 @@ fn main() {
         .arg(
             Arg::new("install")
                 .long("install")
-                .about("Install hardlinks for all subcommands in path")
+                .help("Install hardlinks for all subcommands in path")
                 .exclusive(true)
                 .takes_value(true)
                 .default_missing_value("/usr/local/bin")

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -385,14 +385,14 @@ impl<'help> App<'help> {
         .arg(
             Arg::new("help")
                 .long("help")
-                .about("Print help information")
+                .help("Print help information")
                 .global(true)
                 .generated(),
         )
         .arg(
             Arg::new("version")
                 .long("version")
-                .about("Print version information")
+                .help("Print version information")
                 .global(true)
                 .generated(),
         )
@@ -646,7 +646,7 @@ impl<'help> App<'help> {
     ///             Arg::new("search")
     ///                 .short('s')
     ///                 .long("search")
-    ///                 .about("search remote repositories for matching strings"),
+    ///                 .help("search remote repositories for matching strings"),
     ///         ),
     ///     )
     ///     .get_matches_from(vec!["pacman", "-Ss"]);
@@ -681,7 +681,7 @@ impl<'help> App<'help> {
     ///             Arg::new("search")
     ///                 .short('s')
     ///                 .long("search")
-    ///                 .about("search remote repositories for matching strings"),
+    ///                 .help("search remote repositories for matching strings"),
     ///         ),
     ///     )
     ///     .get_matches_from(vec!["pacman", "--sync", "--search"]);
@@ -1108,7 +1108,7 @@ impl<'help> App<'help> {
     ///     .arg(
     ///         Arg::new("debug")
     ///            .short('d')
-    ///            .about("turns on debugging mode")
+    ///            .help("turns on debugging mode")
     ///     )
     ///     // Adding a single "option" argument with a short, a long, and help text using the less
     ///     // verbose Arg::from()
@@ -1154,7 +1154,7 @@ impl<'help> App<'help> {
     /// App::new("myprog")
     ///     .args(&[
     ///         Arg::from("[debug] -d 'turns on debugging info'"),
-    ///         Arg::new("input").index(1).about("the input file to use")
+    ///         Arg::new("input").index(1).help("the input file to use")
     ///     ])
     /// # ;
     /// ```
@@ -1273,7 +1273,7 @@ impl<'help> App<'help> {
     ///     .subcommand(App::new("test")
     ///         .aliases(&["do-stuff", "do-tests", "tests"]))
     ///         .arg(Arg::new("input")
-    ///             .about("the file to add")
+    ///             .help("the file to add")
     ///             .index(1)
     ///             .required(false))
     ///     .get_matches_from(vec!["myprog", "do-tests"]);
@@ -1298,7 +1298,7 @@ impl<'help> App<'help> {
     ///     .subcommand(App::new("test").short_flag('t')
     ///         .short_flag_aliases(&['a', 'b', 'c']))
     ///         .arg(Arg::new("input")
-    ///             .about("the file to add")
+    ///             .help("the file to add")
     ///             .index(1)
     ///             .required(false))
     ///     .get_matches_from(vec!["myprog", "-a"]);
@@ -1325,7 +1325,7 @@ impl<'help> App<'help> {
     ///             .subcommand(App::new("test").long_flag("test")
     ///                 .long_flag_aliases(&["testing", "testall", "test_all"]))
     ///                 .arg(Arg::new("input")
-    ///                             .about("the file to add")
+    ///                             .help("the file to add")
     ///                             .index(1)
     ///                             .required(false))
     ///             .get_matches_from(vec!["myprog", "--testing"]);
@@ -1836,8 +1836,8 @@ impl<'help> App<'help> {
     /// ```
     /// [`io::stdout()`]: std::io::stdout()
     /// [`BufWriter`]: std::io::BufWriter
-    /// [`-h` (short)]: Arg::about()
-    /// [`--help` (long)]: Arg::long_about()
+    /// [`-h` (short)]: Arg::help()
+    /// [`--help` (long)]: Arg::long_help()
     pub fn print_help(&mut self) -> io::Result<()> {
         self._build();
         let color = self.get_color();
@@ -1863,8 +1863,8 @@ impl<'help> App<'help> {
     /// ```
     /// [`io::stdout()`]: std::io::stdout()
     /// [`BufWriter`]: std::io::BufWriter
-    /// [`-h` (short)]: Arg::about()
-    /// [`--help` (long)]: Arg::long_about()
+    /// [`-h` (short)]: Arg::help()
+    /// [`--help` (long)]: Arg::long_help()
     pub fn print_long_help(&mut self) -> io::Result<()> {
         self._build();
         let color = self.get_color();
@@ -1891,8 +1891,8 @@ impl<'help> App<'help> {
     /// app.write_help(&mut out).expect("failed to write to stdout");
     /// ```
     /// [`io::Write`]: std::io::Write
-    /// [`-h` (short)]: Arg::about()
-    /// [`--help` (long)]: Arg::long_about()
+    /// [`-h` (short)]: Arg::help()
+    /// [`--help` (long)]: Arg::long_help()
     pub fn write_help<W: Write>(&mut self, w: &mut W) -> io::Result<()> {
         self._build();
 
@@ -1917,8 +1917,8 @@ impl<'help> App<'help> {
     /// app.write_long_help(&mut out).expect("failed to write to stdout");
     /// ```
     /// [`io::Write`]: std::io::Write
-    /// [`-h` (short)]: Arg::about()
-    /// [`--help` (long)]: Arg::long_about()
+    /// [`-h` (short)]: Arg::help()
+    /// [`--help` (long)]: Arg::long_help()
     pub fn write_long_help<W: Write>(&mut self, w: &mut W) -> io::Result<()> {
         self._build();
 
@@ -2443,7 +2443,7 @@ impl<'help> App<'help> {
             let args_missing_help: Vec<String> = self
                 .args
                 .args()
-                .filter(|arg| arg.about.is_none() && arg.long_about.is_none())
+                .filter(|arg| arg.help.is_none() && arg.long_help.is_none())
                 .map(|arg| String::from(arg.name))
                 .collect();
 

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -778,7 +778,7 @@ pub enum AppSettings {
     /// App::new("myprog")
     ///     .setting(AppSettings::HelpRequired)
     ///     .arg(
-    ///         Arg::new("foo").about("It does foo stuff")
+    ///         Arg::new("foo").help("It does foo stuff")
     ///         // As required via AppSettings::HelpRequired, a help message was supplied
     ///      )
     /// #    .get_matches();
@@ -987,8 +987,8 @@ pub enum AppSettings {
     ///     .setting(AppSettings::UseLongFormatForHelpSubcommand)
     ///     .subcommand(App::new("test")
     ///         .arg(Arg::new("foo")
-    ///             .about("short form about message")
-    ///             .long_about("long form about message")
+    ///             .help("short form about message")
+    ///             .long_help("long form about message")
     ///         )
     ///     )
     ///     .get_matches();

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -76,7 +76,7 @@ impl Default for ArgProvider {
 ///       .long("config")
 ///       .takes_value(true)
 ///       .value_name("FILE")
-///       .about("Provides a config file to myprog");
+///       .help("Provides a config file to myprog");
 /// // Using a usage string (setting a similar argument to the one above)
 /// let input = Arg::from("-i, --input=[FILE] 'Provides an input file to the program'");
 /// ```
@@ -86,8 +86,8 @@ pub struct Arg<'help> {
     pub(crate) id: Id,
     pub(crate) provider: ArgProvider,
     pub(crate) name: &'help str,
-    pub(crate) about: Option<&'help str>,
-    pub(crate) long_about: Option<&'help str>,
+    pub(crate) help: Option<&'help str>,
+    pub(crate) long_help: Option<&'help str>,
     pub(crate) blacklist: Vec<Id>,
     pub(crate) settings: ArgFlags,
     pub(crate) overrides: Vec<Id>,
@@ -134,8 +134,8 @@ impl<'help> Arg<'help> {
 
     /// Get the help specified for this argument, if any
     #[inline]
-    pub fn get_about(&self) -> Option<&'help str> {
-        self.about
+    pub fn get_help(&self) -> Option<&'help str> {
+        self.help
     }
 
     /// Get the long help specified for this argument, if any
@@ -144,13 +144,13 @@ impl<'help> Arg<'help> {
     ///
     /// ```rust
     /// # use clap::Arg;
-    /// let arg = Arg::new("foo").long_about("long about");
-    /// assert_eq!(Some("long about"), arg.get_long_about());
+    /// let arg = Arg::new("foo").long_help("long help");
+    /// assert_eq!(Some("long help"), arg.get_long_help());
     /// ```
     ///
     #[inline]
-    pub fn get_long_about(&self) -> Option<&'help str> {
-        self.long_about
+    pub fn get_long_help(&self) -> Option<&'help str> {
+        self.long_help
     }
 
     /// Get the help heading specified for this argument, if any
@@ -514,7 +514,7 @@ impl<'help> Arg<'help> {
     ///             .arg(Arg::new("test")
     ///                     .long("test")
     ///                     .aliases(&["do-stuff", "do-tests", "tests"])
-    ///                     .about("the file to add")
+    ///                     .help("the file to add")
     ///                     .required(false))
     ///             .get_matches_from(vec![
     ///                 "prog", "--do-tests"
@@ -539,7 +539,7 @@ impl<'help> Arg<'help> {
     ///             .arg(Arg::new("test")
     ///                     .short('t')
     ///                     .short_aliases(&['e', 's'])
-    ///                     .about("the file to add")
+    ///                     .help("the file to add")
     ///                     .required(false))
     ///             .get_matches_from(vec![
     ///                 "prog", "-s"
@@ -655,10 +655,10 @@ impl<'help> Arg<'help> {
     /// the help information with `-h`. Typically, this is a short (one line) description of the
     /// arg.
     ///
-    /// **NOTE:** If only `Arg::about` is provided, and not [`Arg::long_about`] but the user requests
+    /// **NOTE:** If only `Arg::help` is provided, and not [`Arg::long_help`] but the user requests
     /// `--help` clap will still display the contents of `help` appropriately
     ///
-    /// **NOTE:** Only `Arg::about` is used in completion script generation in order to be concise
+    /// **NOTE:** Only `Arg::help` is used in completion script generation in order to be concise
     ///
     /// # Examples
     ///
@@ -669,11 +669,11 @@ impl<'help> Arg<'help> {
     /// ```rust
     /// # use clap::{App, Arg};
     /// Arg::new("config")
-    ///     .about("The config file used by the myprog")
+    ///     .help("The config file used by the myprog")
     /// # ;
     /// ```
     ///
-    /// Setting `about` displays a short message to the side of the argument when the user passes
+    /// Setting `help` displays a short message to the side of the argument when the user passes
     /// `-h` or `--help` (by default).
     ///
     /// ```rust
@@ -681,7 +681,7 @@ impl<'help> Arg<'help> {
     /// let m = App::new("prog")
     ///     .arg(Arg::new("cfg")
     ///         .long("config")
-    ///         .about("Some help text describing the --config arg"))
+    ///         .help("Some help text describing the --config arg"))
     ///     .get_matches_from(vec![
     ///         "prog", "--help"
     ///     ]);
@@ -700,27 +700,21 @@ impl<'help> Arg<'help> {
     /// -h, --help       Print help information
     /// -V, --version    Print version information
     /// ```
-    /// [`Arg::long_about`]: Arg::long_about()
+    /// [`Arg::long_help`]: Arg::long_help()
     #[inline]
-    pub fn about(mut self, h: &'help str) -> Self {
-        self.about = Some(h);
+    pub fn help(mut self, h: &'help str) -> Self {
+        self.help = Some(h);
         self
-    }
-
-    /// Deprecated, see [`Arg::about`]
-    #[deprecated(since = "3.0.0", note = "Replaced with `Arg::about`")]
-    pub fn help(self, h: &'help str) -> Self {
-        self.about(h)
     }
 
     /// Sets the long help text of the argument that will be displayed to the user when they print
     /// the help information with `--help`. Typically this a more detailed (multi-line) message
     /// that describes the arg.
     ///
-    /// **NOTE:** If only `long_about` is provided, and not [`Arg::about`] but the user requests `-h`
-    /// clap will still display the contents of `long_about` appropriately
+    /// **NOTE:** If only `long_help` is provided, and not [`Arg::help`] but the user requests `-h`
+    /// clap will still display the contents of `long_help` appropriately
     ///
-    /// **NOTE:** Only [`Arg::about`] is used in completion script generation in order to be concise
+    /// **NOTE:** Only [`Arg::help`] is used in completion script generation in order to be concise
     ///
     /// # Examples
     ///
@@ -731,7 +725,7 @@ impl<'help> Arg<'help> {
     /// ```rust
     /// # use clap::{App, Arg};
     /// Arg::new("config")
-    ///     .long_about(
+    ///     .long_help(
     /// "The config file used by the myprog must be in JSON format
     /// with only valid keys and may not contain other nonsense
     /// that cannot be read by this program. Obviously I'm going on
@@ -747,7 +741,7 @@ impl<'help> Arg<'help> {
     /// let m = App::new("prog")
     ///     .arg(Arg::new("cfg")
     ///         .long("config")
-    ///         .long_about(
+    ///         .long_help(
     /// "The config file used by the myprog must be in JSON format
     /// with only valid keys and may not contain other nonsense
     /// that cannot be read by this program. Obviously I'm going on
@@ -778,17 +772,11 @@ impl<'help> Arg<'help> {
     ///     -V, --version
     ///             Print version information
     /// ```
-    /// [`Arg::about`]: Arg::about()
+    /// [`Arg::help`]: Arg::help()
     #[inline]
-    pub fn long_about(mut self, h: &'help str) -> Self {
-        self.long_about = Some(h);
+    pub fn long_help(mut self, h: &'help str) -> Self {
+        self.long_help = Some(h);
         self
-    }
-
-    /// Deprecated, see [`Arg::long_about`]
-    #[deprecated(since = "3.0.0", note = "Replaced with `Arg::long_about`")]
-    pub fn long_help(self, h: &'help str) -> Self {
-        self.long_about(h)
     }
 
     /// Set this arg as [required] as long as the specified argument is not present at runtime.
@@ -1978,7 +1966,7 @@ impl<'help> Arg<'help> {
     /// Arg::new("mode").takes_value(true).possible_values([
     ///     PossibleValue::new("fast"),
     /// // value with a help text
-    ///     PossibleValue::new("slow").about("not that fast"),
+    ///     PossibleValue::new("slow").help("not that fast"),
     /// // value that is hidden from completion and help text
     ///     PossibleValue::new("medium").hidden(true),
     /// ])
@@ -2053,7 +2041,7 @@ impl<'help> Arg<'help> {
     /// Arg::new("mode").takes_value(true)
     ///     .possible_value(PossibleValue::new("fast"))
     /// // value with a help text
-    ///     .possible_value(PossibleValue::new("slow").about("not that fast"))
+    ///     .possible_value(PossibleValue::new("slow").help("not that fast"))
     /// // value that is hidden from completion and help text
     ///     .possible_value(PossibleValue::new("medium").hidden(true))
     /// # ;
@@ -2710,7 +2698,7 @@ impl<'help> Arg<'help> {
     ///     .arg(Arg::new("config")
     ///         .long("config")
     ///         .value_name("FILE")
-    ///         .about("Some help text"))
+    ///         .help("Some help text"))
     ///     .get_matches_from(vec![
     ///         "prog", "--help"
     ///     ]);
@@ -2864,7 +2852,7 @@ impl<'help> Arg<'help> {
     ///                 .min_values(0)
     ///                 .require_equals(true)
     ///                 .default_missing_value("always")
-    ///                 .about("Specify WHEN to colorize output.")
+    ///                 .help("Specify WHEN to colorize output.")
     ///             )
     ///    }};
     /// }
@@ -3363,7 +3351,7 @@ impl<'help> Arg<'help> {
     ///         .long("long-option")
     ///         .short('o')
     ///         .takes_value(true)
-    ///         .about("Some help and text"))
+    ///         .help("Some help and text"))
     ///     .arg(Arg::new("b")
     ///         .long("other-option")
     ///         .short('O')
@@ -3372,7 +3360,7 @@ impl<'help> Arg<'help> {
     ///                             // all we have to do is give it a value lower than 999.
     ///                             // Any other args with a value of 1 will be displayed
     ///                             // alphabetically with this one...then 2 values, then 3, etc.
-    ///         .about("I should be first!"))
+    ///         .help("I should be first!"))
     ///     .get_matches_from(vec![
     ///         "prog", "--help"
     ///     ]);
@@ -3949,7 +3937,7 @@ impl<'help> Arg<'help> {
     ///     .arg(Arg::new("cfg")
     ///         .long("config")
     ///         .setting(ArgSettings::Hidden)
-    ///         .about("Some help text describing the --config arg"))
+    ///         .help("Some help text describing the --config arg"))
     ///     .get_matches_from(vec![
     ///         "prog", "--help"
     ///     ]);
@@ -4188,7 +4176,7 @@ impl<'help> Arg<'help> {
     ///         .setting(ArgSettings::TakesValue)
     ///         .setting(ArgSettings::NextLineHelp)
     ///         .value_names(&["value1", "value2"])
-    ///         .about("Some really long help and complex\n\
+    ///         .help("Some really long help and complex\n\
     ///                help that makes more sense to be\n\
     ///                on a line after the option"))
     ///     .get_matches_from(vec![
@@ -4589,7 +4577,7 @@ impl<'help> Arg<'help> {
     ///     .arg(Arg::new("cfg")
     ///         .long("config")
     ///         .hidden_short_help(true)
-    ///         .about("Some help text describing the --config arg"))
+    ///         .help("Some help text describing the --config arg"))
     ///     .get_matches_from(vec![
     ///         "prog", "-h"
     ///     ]);
@@ -4616,7 +4604,7 @@ impl<'help> Arg<'help> {
     ///     .arg(Arg::new("cfg")
     ///         .long("config")
     ///         .hidden_short_help(true)
-    ///         .about("Some help text describing the --config arg"))
+    ///         .help("Some help text describing the --config arg"))
     ///     .get_matches_from(vec![
     ///         "prog", "--help"
     ///     ]);
@@ -4667,7 +4655,7 @@ impl<'help> Arg<'help> {
     ///     .arg(Arg::new("cfg")
     ///         .long("config")
     ///         .hidden_long_help(true)
-    ///         .about("Some help text describing the --config arg"))
+    ///         .help("Some help text describing the --config arg"))
     ///     .get_matches_from(vec![
     ///         "prog", "--help"
     ///     ]);
@@ -4694,7 +4682,7 @@ impl<'help> Arg<'help> {
     ///     .arg(Arg::new("cfg")
     ///         .long("config")
     ///         .hidden_long_help(true)
-    ///         .about("Some help text describing the --config arg"))
+    ///         .help("Some help text describing the --config arg"))
     ///     .get_matches_from(vec![
     ///         "prog", "-h"
     ///     ]);
@@ -4955,8 +4943,8 @@ impl<'help> From<&'help Yaml> for Arg<'help> {
                 "aliases" => yaml_vec_or_str!(a, v, alias),
                 "short_alias" => yaml_to_str!(a, v, alias),
                 "short_aliases" => yaml_to_chars!(a, v, short_aliases),
-                "about" => yaml_to_str!(a, v, about),
-                "long_about" => yaml_to_str!(a, v, long_about),
+                "help" => yaml_to_str!(a, v, help),
+                "long_help" => yaml_to_str!(a, v, long_help),
                 "required" => yaml_to_bool!(a, v, required),
                 "required_if_eq" => yaml_tuple2!(a, v, required_if_eq),
                 "required_if_eq_any" => yaml_array_tuple2!(a, v, required_if_eq_any),
@@ -5193,8 +5181,8 @@ impl<'help> fmt::Debug for Arg<'help> {
             .field("id", &self.id)
             .field("provider", &self.provider)
             .field("name", &self.name)
-            .field("about", &self.about)
-            .field("long_about", &self.long_about)
+            .field("help", &self.help)
+            .field("long_help", &self.long_help)
             .field("blacklist", &self.blacklist)
             .field("settings", &self.settings)
             .field("overrides", &self.overrides)

--- a/src/build/arg/possible_value.rs
+++ b/src/build/arg/possible_value.rs
@@ -7,7 +7,7 @@ use crate::util::eq_ignore_case;
 /// This is used for specifying [possible values] of [Args].
 ///
 /// **NOTE:** This struct is likely not needed for most usecases as it is only required to
-/// [hide] single values from help messages and shell completions or to attach [about] to possible values.
+/// [hide] single values from help messages and shell completions or to attach [help] to possible values.
 ///
 /// # Examples
 ///
@@ -17,17 +17,17 @@ use crate::util::eq_ignore_case;
 ///       .takes_value(true)
 ///       .value_name("FILE")
 ///       .possible_value(PossibleValue::new("fast"))
-///       .possible_value(PossibleValue::new("slow").about("slower than fast"))
+///       .possible_value(PossibleValue::new("slow").help("slower than fast"))
 ///       .possible_value(PossibleValue::new("secret speed").hidden(true));
 /// ```
 /// [Args]: crate::Arg
 /// [possible values]: crate::Arg::possible_value()
 /// [hide]: PossibleValue::hidden()
-/// [about]: PossibleValue::about()
+/// [help]: PossibleValue::help()
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PossibleValue<'help> {
     pub(crate) name: &'help str,
-    pub(crate) about: Option<&'help str>,
+    pub(crate) help: Option<&'help str>,
     pub(crate) aliases: Vec<&'help str>, // (name, visible)
     pub(crate) hidden: bool,
 }
@@ -54,8 +54,8 @@ impl<'help> PossibleValue<'help> {
 
     /// Get the help specified for this argument, if any
     #[inline]
-    pub fn get_about(&self) -> Option<&str> {
-        self.about
+    pub fn get_help(&self) -> Option<&str> {
+        self.help
     }
 
     /// Should the value be hidden from help messages and completion
@@ -137,12 +137,12 @@ impl<'help> PossibleValue<'help> {
     /// ```rust
     /// # use clap::PossibleValue;
     /// PossibleValue::new("slow")
-    ///     .about("not fast")
+    ///     .help("not fast")
     /// # ;
     /// ```
     #[inline]
-    pub fn about(mut self, about: &'help str) -> Self {
-        self.about = Some(about);
+    pub fn help(mut self, help: &'help str) -> Self {
+        self.help = Some(help);
         self
     }
 

--- a/src/build/arg/tests.rs
+++ b/src/build/arg/tests.rs
@@ -6,7 +6,7 @@ fn short_flag_misspell() {
     assert_eq!(a.name, "flag");
     assert_eq!(a.short.unwrap(), 'f');
     assert_eq!(a.long.unwrap(), "flag");
-    assert_eq!(a.about.unwrap(), "some flag");
+    assert_eq!(a.help.unwrap(), "some flag");
     assert!(!a.is_set(ArgSettings::MultipleOccurrences));
     assert!(a.val_names.is_empty());
     assert!(a.num_vals.is_none());
@@ -18,7 +18,7 @@ fn short_flag_name_missing() {
     assert_eq!(a.name, "f");
     assert_eq!(a.short.unwrap(), 'f');
     assert!(a.long.is_none());
-    assert_eq!(a.about.unwrap(), "some flag");
+    assert_eq!(a.help.unwrap(), "some flag");
     assert!(!a.is_set(ArgSettings::MultipleOccurrences));
     assert!(a.val_names.is_empty());
     assert!(a.num_vals.is_none());

--- a/src/build/usage_parser.rs
+++ b/src/build/usage_parser.rs
@@ -196,7 +196,7 @@ impl<'help> UsageParser<'help> {
             "UsageParser::help: setting help...{}",
             &self.usage[self.start..self.pos]
         );
-        arg.about = Some(&self.usage[self.start..self.pos]);
+        arg.help = Some(&self.usage[self.start..self.pos]);
         self.pos += 1; // Move to next byte to keep from thinking ending ' is a start
         self.prev = UsageToken::Help;
     }
@@ -254,7 +254,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.short.unwrap(), 'f');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_empty());
 
@@ -262,7 +262,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.long.unwrap(), "flag");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_empty());
 
@@ -270,7 +270,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.long.unwrap(), "flag");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_empty());
 
@@ -278,7 +278,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.short.unwrap(), 'f');
         assert_eq!(a.long.unwrap(), "flag");
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_empty());
 
@@ -286,7 +286,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.short.unwrap(), 'f');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_empty());
 
@@ -294,7 +294,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.long.unwrap(), "flag");
         assert_eq!(a.short.unwrap(), 'f');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_empty());
 
@@ -302,7 +302,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.long.unwrap(), "flag");
         assert_eq!(a.short.unwrap(), 'f');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_empty());
 
@@ -332,7 +332,7 @@ mod test {
         assert_eq!(a.name, "f");
         assert_eq!(a.short.unwrap(), 'f');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_empty());
 
@@ -355,7 +355,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -369,7 +369,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -383,7 +383,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -397,7 +397,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -411,7 +411,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -425,7 +425,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -439,7 +439,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -453,7 +453,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -467,7 +467,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -481,7 +481,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -495,7 +495,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -509,7 +509,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -523,7 +523,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -537,7 +537,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -551,7 +551,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -565,7 +565,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -579,7 +579,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -593,7 +593,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -607,7 +607,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -621,7 +621,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -635,7 +635,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -649,7 +649,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -663,7 +663,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -677,7 +677,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -691,7 +691,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -705,7 +705,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -719,7 +719,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -733,7 +733,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -747,7 +747,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -761,7 +761,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -775,7 +775,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -789,7 +789,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -803,7 +803,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -817,7 +817,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -831,7 +831,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -845,7 +845,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -859,7 +859,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -873,7 +873,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -887,7 +887,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -901,7 +901,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -915,7 +915,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -929,7 +929,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -943,7 +943,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -957,7 +957,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -971,7 +971,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -985,7 +985,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -999,7 +999,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -1013,7 +1013,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert!(a.long.is_none());
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -1027,7 +1027,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert!(a.long.is_none());
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -1041,7 +1041,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert!(a.short.is_none());
         assert_eq!(a.long.unwrap(), "opt");
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -1055,7 +1055,7 @@ mod test {
         assert_eq!(a.name, "myopt");
         assert!(a.short.is_none());
         assert_eq!(a.long.unwrap(), "opt");
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -1069,7 +1069,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert!(a.short.is_none());
         assert_eq!(a.long.unwrap(), "opt");
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -1080,7 +1080,7 @@ mod test {
     fn create_positional_usage() {
         let a = Arg::from("[pos] 'some help info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(!a.is_set(ArgSettings::Required));
@@ -1091,7 +1091,7 @@ mod test {
     fn create_positional_usage0() {
         let a = Arg::from("<pos> 'some help info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::Required));
@@ -1102,7 +1102,7 @@ mod test {
     fn pos_mult_help() {
         let a = Arg::from("[pos]... 'some help info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(!a.is_set(ArgSettings::Required));
@@ -1113,7 +1113,7 @@ mod test {
     fn pos_help_lit_single_quote() {
         let a = Arg::from("[pos]... 'some help\' info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.about.unwrap(), "some help' info");
+        assert_eq!(a.help.unwrap(), "some help' info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(!a.is_set(ArgSettings::Required));
@@ -1124,7 +1124,7 @@ mod test {
     fn pos_help_double_lit_single_quote() {
         let a = Arg::from("[pos]... 'some \'help\' info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.about.unwrap(), "some 'help' info");
+        assert_eq!(a.help.unwrap(), "some 'help' info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(!a.is_set(ArgSettings::Required));
@@ -1138,7 +1138,7 @@ mod test {
              info'",
         );
         assert_eq!(a.name, "pos");
-        assert_eq!(a.about.unwrap(), "some help\ninfo");
+        assert_eq!(a.help.unwrap(), "some help\ninfo");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(!a.is_set(ArgSettings::Required));
@@ -1152,7 +1152,7 @@ mod test {
              info'",
         );
         assert_eq!(a.name, "pos");
-        assert_eq!(a.about.unwrap(), "some help' stuff\ninfo");
+        assert_eq!(a.help.unwrap(), "some help' stuff\ninfo");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(!a.is_set(ArgSettings::Required));
@@ -1163,7 +1163,7 @@ mod test {
     fn pos_req_mult_help() {
         let a = Arg::from("<pos>... 'some help info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::Required));
@@ -1194,7 +1194,7 @@ mod test {
     fn pos_req_mult_def_help() {
         let a = Arg::from("<pos>... @a 'some help info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::Required));
@@ -1208,7 +1208,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert!(a.long.is_none());
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -1223,7 +1223,7 @@ mod test {
         assert_eq!(a.name, "myopt");
         assert!(a.short.is_none());
         assert_eq!(a.long.unwrap(), "opt");
-        assert_eq!(a.about.unwrap(), "some help info");
+        assert_eq!(a.help.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -1236,25 +1236,25 @@ mod test {
     fn nonascii() {
         let a = Arg::from("<ASCII> 'üñíčöĐ€'");
         assert_eq!(a.name, "ASCII");
-        assert_eq!(a.about, Some("üñíčöĐ€"));
+        assert_eq!(a.help, Some("üñíčöĐ€"));
         let a = Arg::from("<üñíčöĐ€> 'ASCII'");
         assert_eq!(a.name, "üñíčöĐ€");
-        assert_eq!(a.about, Some("ASCII"));
+        assert_eq!(a.help, Some("ASCII"));
         let a = Arg::from("<üñíčöĐ€> 'üñíčöĐ€'");
         assert_eq!(a.name, "üñíčöĐ€");
-        assert_eq!(a.about, Some("üñíčöĐ€"));
+        assert_eq!(a.help, Some("üñíčöĐ€"));
         let a = Arg::from("-ø 'ø'");
         assert_eq!(a.name, "ø");
         assert_eq!(a.short, Some('ø'));
-        assert_eq!(a.about, Some("ø"));
+        assert_eq!(a.help, Some("ø"));
         let a = Arg::from("--üñíčöĐ€ 'Nōṫ ASCII'");
         assert_eq!(a.name, "üñíčöĐ€");
         assert_eq!(a.long, Some("üñíčöĐ€"));
-        assert_eq!(a.about, Some("Nōṫ ASCII"));
+        assert_eq!(a.help, Some("Nōṫ ASCII"));
         let a = Arg::from("[ñämê] --ôpt=[üñíčöĐ€] 'hælp'");
         assert_eq!(a.name, "ñämê");
         assert_eq!(a.long, Some("ôpt"));
         assert_eq!(a.val_names.iter().collect::<Vec<_>>(), [&"üñíčöĐ€"]);
-        assert_eq!(a.about, Some("hælp"));
+        assert_eq!(a.help, Some("hælp"));
     }
 }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -48,11 +48,11 @@ use std::ffi::OsString;
 ///     .about("My super CLI")
 ///     .arg(Arg::new("verbose")
 ///         .long("verbose")
-///         .about("More verbose output"))
+///         .help("More verbose output"))
 ///     .arg(Arg::new("name")
 ///         .long("name")
 ///         .short('n')
-///         .about("An optional name")
+///         .help("An optional name")
 ///         .takes_value(true));
 ///
 /// struct Context {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -457,7 +457,7 @@ macro_rules! clap_app {
     };
     (@as_expr $expr:expr) => { $expr };
     // Help
-    (@arg ($arg:expr) $modes:tt $desc:tt) => { $arg.about($crate::clap_app!{ @as_expr $desc }) };
+    (@arg ($arg:expr) $modes:tt $desc:tt) => { $arg.help($crate::clap_app!{ @as_expr $desc }) };
     // Handle functions that need to be called multiple times for each argument
     (@arg ($arg:expr) $modes:tt $ident:ident[$($target:literal)*] $($tail:tt)*) => {
         $crate::clap_app!{ @arg ($arg $( .$ident(stringify!($target).trim_matches('"')) )*) $modes $($tail)* }

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -457,9 +457,9 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
         self.val(arg, next_line_help, longest)?;
 
         let about = if self.use_long {
-            arg.long_about.unwrap_or_else(|| arg.about.unwrap_or(""))
+            arg.long_help.unwrap_or_else(|| arg.help.unwrap_or(""))
         } else {
-            arg.about.unwrap_or_else(|| arg.long_about.unwrap_or(""))
+            arg.help.unwrap_or_else(|| arg.long_help.unwrap_or(""))
         };
 
         self.help(
@@ -488,7 +488,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
             true
         } else {
             // force_next_line
-            let h = arg.about.unwrap_or("");
+            let h = arg.help.unwrap_or("");
             let h_w = display_width(h) + display_width(spec_vals);
             let taken = longest + 12;
             self.term_w >= taken
@@ -605,7 +605,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
             spec_vals.push(format!("[possible values: {}]", pvs));
         }
         let connector = if self.use_long { "\n" } else { " " };
-        let prefix = if !spec_vals.is_empty() && !a.get_about().unwrap_or("").is_empty() {
+        let prefix = if !spec_vals.is_empty() && !a.get_help().unwrap_or("").is_empty() {
             if self.use_long {
                 "\n\n"
             } else {

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -70,7 +70,7 @@ pub enum ErrorKind {
     ///     .subcommand(App::new("config")
     ///         .about("Used for configuration")
     ///         .arg(Arg::new("config_file")
-    ///             .about("The configuration file to use")
+    ///             .help("The configuration file to use")
     ///             .index(1)))
     ///     .try_get_matches_from(vec!["prog", "confi"]);
     /// assert!(result.is_err());
@@ -97,7 +97,7 @@ pub enum ErrorKind {
     ///     .subcommand(App::new("config")
     ///         .about("Used for configuration")
     ///         .arg(Arg::new("config_file")
-    ///             .about("The configuration file to use")
+    ///             .help("The configuration file to use")
     ///             .index(1)))
     ///     .try_get_matches_from(vec!["prog", "help", "nothing"]);
     /// assert!(result.is_err());
@@ -376,7 +376,7 @@ pub enum ErrorKind {
     ///     .subcommand(App::new("config")
     ///         .about("Used for configuration")
     ///         .arg(Arg::new("config_file")
-    ///             .about("The configuration file to use")))
+    ///             .help("The configuration file to use")))
     ///     .try_get_matches_from(vec!["prog"]);
     /// assert!(result.is_err());
     /// assert_eq!(result.unwrap_err().kind, ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand);

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -925,7 +925,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                         .setting(ArgSettings::TakesValue)
                         .setting(ArgSettings::MultipleOccurrences)
                         .value_name("SUBCOMMAND")
-                        .about("The subcommand whose help message to display");
+                        .help("The subcommand whose help message to display");
                     sc = sc.arg(pb);
                 }
 
@@ -1137,7 +1137,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         // specified by the user is sent through. If HiddenShortHelp is not included,
         // then items specified with hidden_short_help will also be hidden.
         let should_long = |v: &Arg| {
-            v.long_about.is_some()
+            v.long_help.is_some()
                 || v.is_set(ArgSettings::HiddenLongHelp)
                 || v.is_set(ArgSettings::HiddenShortHelp)
         };

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -88,7 +88,7 @@ USAGE:
 
 ARGS:
     <foo>
-            long form about message
+            long form help message
 
 OPTIONS:
     -h, --help
@@ -114,7 +114,7 @@ USAGE:
 
 ARGS:
     <foo>
-            long form about message
+            long form help message
 
 OPTIONS:
     -h, --help
@@ -268,7 +268,7 @@ fn arg_required_else_help_error_message() {
         .version("1.0")
         .arg(
             Arg::new("info")
-                .about("Provides more info")
+                .help("Provides more info")
                 .short('i')
                 .long("info"),
         );
@@ -634,9 +634,9 @@ fn dont_collapse_args() {
         .version("v1.4.8")
         .setting(AppSettings::DontCollapseArgsInUsage)
         .args(&[
-            Arg::new("arg1").about("some"),
-            Arg::new("arg2").about("some"),
-            Arg::new("arg3").about("some"),
+            Arg::new("arg1").help("some"),
+            Arg::new("arg2").help("some"),
+            Arg::new("arg3").help("some"),
         ]);
     assert!(utils::compare_output(
         app,
@@ -655,7 +655,7 @@ fn require_eq() {
             .required(true)
             .require_equals(true)
             .value_name("FILE")
-            .about("some"),
+            .help("some"),
     );
     assert!(utils::compare_output(
         app,
@@ -1126,8 +1126,8 @@ fn single_arg_help_with_long_format_setting() {
         .subcommand(App::new("test"))
         .arg(
             Arg::new("foo")
-                .about("short form about message")
-                .long_about("long form about message"),
+                .help("short form help message")
+                .long_help("long form help message"),
         );
     assert!(utils::compare_output(
         m,
@@ -1144,8 +1144,8 @@ fn use_long_format_for_help_subcommand_with_setting() {
         .subcommand(
             App::new("test").arg(
                 Arg::new("foo")
-                    .about("short form about message")
-                    .long_about("long form about message"),
+                    .help("short form help message")
+                    .long_help("long form help message"),
             ),
         );
     assert!(utils::compare_output(
@@ -1201,7 +1201,7 @@ fn no_auto_version() {
 fn no_auto_version_mut_arg() {
     let app = App::new("myprog")
         .version("3.0")
-        .mut_arg("version", |v| v.about("custom about"))
+        .mut_arg("version", |v| v.help("custom help"))
         .setting(AppSettings::NoAutoVersion);
 
     let result = app

--- a/tests/arg_aliases.rs
+++ b/tests/arg_aliases.rs
@@ -37,7 +37,7 @@ fn single_alias_of_option() {
             Arg::new("alias")
                 .long("alias")
                 .takes_value(true)
-                .about("single alias")
+                .help("single alias")
                 .alias("new-opt"),
         )
         .try_get_matches_from(vec!["", "--new-opt", "cool"]);
@@ -53,7 +53,7 @@ fn multiple_aliases_of_option() {
         Arg::new("aliases")
             .long("aliases")
             .takes_value(true)
-            .about("multiple aliases")
+            .help("multiple aliases")
             .aliases(&["alias1", "alias2", "alias3"]),
     );
     let long = a
@@ -142,7 +142,7 @@ fn alias_on_a_subcommand_option() {
                     .long("test")
                     .takes_value(true)
                     .alias("opt")
-                    .about("testing testing"),
+                    .help("testing testing"),
             ),
         )
         .arg(Arg::new("other").long("other").aliases(&["o1", "o2", "o3"]))

--- a/tests/arg_aliases_short.rs
+++ b/tests/arg_aliases_short.rs
@@ -37,7 +37,7 @@ fn single_short_alias_of_option() {
             Arg::new("alias")
                 .long("alias")
                 .takes_value(true)
-                .about("single short alias")
+                .help("single short alias")
                 .short_alias('a'),
         )
         .try_get_matches_from(vec!["", "-a", "cool"]);
@@ -53,7 +53,7 @@ fn multiple_short_aliases_of_option() {
         Arg::new("aliases")
             .long("aliases")
             .takes_value(true)
-            .about("multiple aliases")
+            .help("multiple aliases")
             .short_aliases(&['1', '2', '3']),
     );
     let long = a
@@ -134,7 +134,7 @@ fn short_alias_on_a_subcommand_option() {
                     .long("test")
                     .takes_value(true)
                     .short_alias('o')
-                    .about("testing testing"),
+                    .help("testing testing"),
             ),
         )
         .arg(

--- a/tests/borrowed.rs
+++ b/tests/borrowed.rs
@@ -2,11 +2,11 @@ use clap::{App, Arg};
 
 #[test]
 fn borrowed_args() {
-    let arg = Arg::new("some").short('s').long("some").about("other help");
+    let arg = Arg::new("some").short('s').long("some").help("other help");
     let arg2 = Arg::new("some2")
         .short('S')
         .long("some-thing")
-        .about("other help");
+        .help("other help");
     let result = App::new("sub_command_negate")
         .arg(Arg::new("test").index(1))
         .arg(&arg)

--- a/tests/default_vals.rs
+++ b/tests/default_vals.rs
@@ -617,7 +617,7 @@ fn with_value_delimiter() {
     let app = App::new("multiple_values").arg(
         Arg::new("option")
             .long("option")
-            .about("multiple options")
+            .help("multiple options")
             .value_delimiter(';')
             .default_value("first;second"),
     );

--- a/tests/derive_order.rs
+++ b/tests/derive_order.rs
@@ -87,16 +87,16 @@ OPTIONS:
 #[test]
 fn no_derive_order() {
     let app = App::new("test").version("1.2").args(&[
-        Arg::new("flag_b").long("flag_b").about("first flag"),
+        Arg::new("flag_b").long("flag_b").help("first flag"),
         Arg::new("option_b")
             .long("option_b")
             .takes_value(true)
-            .about("first option"),
-        Arg::new("flag_a").long("flag_a").about("second flag"),
+            .help("first option"),
+        Arg::new("flag_a").long("flag_a").help("second flag"),
         Arg::new("option_a")
             .long("option_a")
             .takes_value(true)
-            .about("second option"),
+            .help("second option"),
     ]);
 
     assert!(utils::compare_output(
@@ -113,16 +113,16 @@ fn derive_order() {
         .setting(AppSettings::DeriveDisplayOrder)
         .version("1.2")
         .args(&[
-            Arg::new("flag_b").long("flag_b").about("first flag"),
+            Arg::new("flag_b").long("flag_b").help("first flag"),
             Arg::new("option_b")
                 .long("option_b")
                 .takes_value(true)
-                .about("first option"),
-            Arg::new("flag_a").long("flag_a").about("second flag"),
+                .help("first option"),
+            Arg::new("flag_a").long("flag_a").help("second flag"),
             Arg::new("option_a")
                 .long("option_a")
                 .takes_value(true)
-                .about("second option"),
+                .help("second option"),
         ]);
 
     assert!(utils::compare_output(
@@ -139,16 +139,16 @@ fn derive_order_subcommand_propagate() {
         .global_setting(AppSettings::DeriveDisplayOrder)
         .subcommand(
             App::new("sub").version("1.2").args(&[
-                Arg::new("flag_b").long("flag_b").about("first flag"),
+                Arg::new("flag_b").long("flag_b").help("first flag"),
                 Arg::new("option_b")
                     .long("option_b")
                     .takes_value(true)
-                    .about("first option"),
-                Arg::new("flag_a").long("flag_a").about("second flag"),
+                    .help("first option"),
+                Arg::new("flag_a").long("flag_a").help("second flag"),
                 Arg::new("option_a")
                     .long("option_a")
                     .takes_value(true)
-                    .about("second option"),
+                    .help("second option"),
             ]),
         );
 
@@ -166,19 +166,19 @@ fn derive_order_subcommand_propagate_with_explicit_display_order() {
         .global_setting(AppSettings::DeriveDisplayOrder)
         .subcommand(
             App::new("sub").version("1.2").args(&[
-                Arg::new("flag_b").long("flag_b").about("first flag"),
+                Arg::new("flag_b").long("flag_b").help("first flag"),
                 Arg::new("option_b")
                     .long("option_b")
                     .takes_value(true)
-                    .about("first option"),
+                    .help("first option"),
                 Arg::new("flag_a")
                     .long("flag_a")
-                    .about("second flag")
+                    .help("second flag")
                     .display_order(0),
                 Arg::new("option_a")
                     .long("option_a")
                     .takes_value(true)
-                    .about("second option"),
+                    .help("second option"),
             ]),
         );
 
@@ -199,9 +199,9 @@ fn prefer_user_help_with_derive_order() {
             Arg::new("help")
                 .long("help")
                 .short('h')
-                .about("Print help message"),
-            Arg::new("flag_b").long("flag_b").about("first flag"),
-            Arg::new("flag_a").long("flag_a").about("second flag"),
+                .help("Print help message"),
+            Arg::new("flag_b").long("flag_b").help("first flag"),
+            Arg::new("flag_a").long("flag_a").help("second flag"),
         ]);
 
     assert!(utils::compare_output(
@@ -221,9 +221,9 @@ fn prefer_user_help_in_subcommand_with_derive_order() {
                 Arg::new("help")
                     .long("help")
                     .short('h')
-                    .about("Print help message"),
-                Arg::new("flag_b").long("flag_b").about("first flag"),
-                Arg::new("flag_a").long("flag_a").about("second flag"),
+                    .help("Print help message"),
+                Arg::new("flag_b").long("flag_b").help("first flag"),
+                Arg::new("flag_a").long("flag_a").help("second flag"),
             ]),
         );
 

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -35,22 +35,22 @@ For more information try --help
                 .short('a')
                 .long("all")
                 .required(true)
-                .about("Also do versioning for private crates (will not be published)"),
+                .help("Also do versioning for private crates (will not be published)"),
         )
         .arg(
             Arg::new("exact")
                 .long("exact")
-                .about("Specify inter dependency version numbers exactly with `=`"),
+                .help("Specify inter dependency version numbers exactly with `=`"),
         )
         .arg(
             Arg::new("no_git_commit")
                 .long("no-git-commit")
-                .about("Do not commit version changes"),
+                .help("Do not commit version changes"),
         )
         .arg(
             Arg::new("no_git_push")
                 .long("no-git-push")
-                .about("Do not push generated commit and tags to git remote"),
+                .help("Do not push generated commit and tags to git remote"),
         );
     let mut app = app;
     let expected_kind = ErrorKind::InvalidValue;

--- a/tests/fixtures/app.yaml
+++ b/tests/fixtures/app.yaml
@@ -8,18 +8,18 @@ args:
     - help:
         short: h
         long: help
-        about: prints help with a nonstandard description
+        help: prints help with a nonstandard description
     - option:
         short: o
         long: option
         takes_value: true
         multiple_values: true
-        about: tests options
+        help: tests options
     - positional:
-        about: tests positionals
+        help: tests positionals
         index: 1
     - positional2:
-        about: tests positionals with exclusions
+        help: tests positionals with exclusions
         index: 2
         default_value_if:
             - [flag, null, some]
@@ -29,18 +29,18 @@ args:
         long: flag
         takes_value: true
         multiple_values: true
-        about: tests flags
+        help: tests flags
         global: true
     - flag2:
         short: F
-        about: tests flags with exclusions
+        help: tests flags with exclusions
         conflicts_with:
             - flag
         requires:
             - option2
     - option2:
         long: long-option-2
-        about: tests long options with exclusions
+        help: tests long options with exclusions
         conflicts_with:
             - option
         requires:
@@ -48,7 +48,7 @@ args:
     - option3:
         short: O
         long: option3
-        about: tests options with specific value sets
+        help: tests options with specific value sets
         takes_value: true
         possible_values:
             - fast
@@ -57,22 +57,22 @@ args:
             - [fast, flag]
     - positional3:
         index: 3
-        about: tests positionals with specific values
+        help: tests positionals with specific values
         possible_values: [ vi, emacs ]
     - multvals:
         long: multvals
-        about: Tests multiple values, not mult occs
+        help: Tests multiple values, not mult occs
         value_names:
             - one
             - two
     - multvalsmo:
         long: multvalsmo
         multiple_values: true
-        about: Tests multiple values, not mult occs
+        help: Tests multiple values, not mult occs
         value_names: [one, two]
     - multvalsdelim:
         long: multvalsdelim
-        about: Tests multiple values with required delimiter
+        help: Tests multiple values with required delimiter
         takes_value: true
         multiple_occurrences: true
         use_delimiter: true
@@ -83,60 +83,60 @@ args:
         multiple_values: true
     - singlealias:
         long: singlealias
-        about: Tests single alias
+        help: Tests single alias
         aliases: [alias]
         required_if_eq:
             - [multvalsmo, two]
     - multaliases:
         long: multaliases
-        about: Tests multiple aliases
+        help: Tests multiple aliases
         aliases: [als1, als2, als3]
     - singleshortalias:
         long: singleshortalias
-        about: Tests single short alias
+        help: Tests single short alias
         short_aliases: [a]
         required_if_eq:
             - [multvalsmo, two]
     - multshortaliases:
         long: multshortaliases
-        about: Tests multiple short aliases
+        help: Tests multiple short aliases
         short_aliases: [b, c]
     - minvals2:
         long: minvals2
         multiple_values: true
-        about: Tests 2 min vals
+        help: Tests 2 min vals
         min_values: 2
     - maxvals3:
         long: maxvals3
         multiple_values: true
-        about: Tests 3 max vals
+        help: Tests 3 max vals
         max_values: 3
     - exclusive:
         long: exclusive
-        about: Tests 3 exclusive
+        help: Tests 3 exclusive
         exclusive: true
     - case_insensitive:
         index: 4
-        about: Test case_insensitive
+        help: Test case_insensitive
         possible_values: [test123, test321]
         case_insensitive: true
     - value_hint:
         long: value-hint
-        about: Test value_hint
+        help: Test value_hint
         value_hint: FilePath
     - verbose:
         short: v
         multiple_occurrences: true
         takes_value: false
-        about: Sets the level of verbosity
+        help: Sets the level of verbosity
     - visiblealiases:
         long: visiblealiases
-        about: Tests visible aliases
+        help: Tests visible aliases
         visible_alias: visals1
         visible_aliases: [visals2, visals2, visals3]
     - visibleshortaliases:
         long: visibleshortaliases
-        about: Tests visible short aliases
+        help: Tests visible short aliases
         visible_short_alias: e
         visible_short_aliases: [l, m]
 groups:
@@ -158,8 +158,8 @@ subcommands:
                 short: o
                 long: option
                 multiple_values: true
-                about: tests options
+                help: tests options
                 takes_value: true
             - scpositional:
-                about: tests positionals
+                help: tests positionals
                 index: 1

--- a/tests/fixtures/app_2space.yaml
+++ b/tests/fixtures/app_2space.yaml
@@ -8,4 +8,4 @@ args:
     long: option
     takes_value: true
     multiple_values: true
-    about: tests options
+    help: tests options

--- a/tests/fixtures/app_regex.yaml
+++ b/tests/fixtures/app_regex.yaml
@@ -6,4 +6,4 @@ args:
     - filter:
         index: 1
         validator_regex: ["^*\\.[a-z]+$", expected extension pattern]
-        about: file extension pattern
+        help: file extension pattern

--- a/tests/flag_subcommands.rs
+++ b/tests/flag_subcommands.rs
@@ -10,7 +10,7 @@ fn flag_subcommand_normal() {
                 Arg::new("test")
                     .short('t')
                     .long("test")
-                    .about("testing testing"),
+                    .help("testing testing"),
             ),
         )
         .get_matches_from(vec!["myprog", "some", "--test"]);
@@ -30,7 +30,7 @@ fn flag_subcommand_normal_with_alias() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .about("testing testing"),
+                        .help("testing testing"),
                 )
                 .alias("result"),
         )
@@ -48,7 +48,7 @@ fn flag_subcommand_short() {
                 Arg::new("test")
                     .short('t')
                     .long("test")
-                    .about("testing testing"),
+                    .help("testing testing"),
             ),
         )
         .get_matches_from(vec!["myprog", "-S", "--test"]);
@@ -65,7 +65,7 @@ fn flag_subcommand_short_with_args() {
                 Arg::new("test")
                     .short('t')
                     .long("test")
-                    .about("testing testing"),
+                    .help("testing testing"),
             ),
         )
         .get_matches_from(vec!["myprog", "-St"]);
@@ -84,7 +84,7 @@ fn flag_subcommand_short_with_alias() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .about("testing testing"),
+                        .help("testing testing"),
                 )
                 .short_flag_alias('M')
                 .short_flag_alias('B'),
@@ -120,7 +120,7 @@ fn flag_subcommand_short_with_aliases_vis_and_hidden() {
                 Arg::new("test")
                     .short('t')
                     .long("test")
-                    .about("testing testing"),
+                    .help("testing testing"),
             )
             .visible_short_flag_aliases(&['M', 'B'])
             .short_flag_alias('C'),
@@ -148,7 +148,7 @@ fn flag_subcommand_short_with_aliases() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .about("testing testing"),
+                        .help("testing testing"),
                 )
                 .short_flag_aliases(&['M', 'B']),
         )
@@ -169,7 +169,7 @@ fn flag_subcommand_short_with_alias_hyphen() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .about("testing testing"),
+                        .help("testing testing"),
                 )
                 .short_flag_alias('-'),
         )
@@ -187,7 +187,7 @@ fn flag_subcommand_short_with_aliases_hyphen() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .about("testing testing"),
+                        .help("testing testing"),
                 )
                 .short_flag_aliases(&['-', '-', '-']),
         )
@@ -218,7 +218,7 @@ fn flag_subcommand_long() {
                 Arg::new("test")
                     .short('t')
                     .long("test")
-                    .about("testing testing"),
+                    .help("testing testing"),
             ),
         )
         .get_matches_from(vec!["myprog", "--some", "--test"]);
@@ -237,7 +237,7 @@ fn flag_subcommand_long_with_alias() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .about("testing testing"),
+                        .help("testing testing"),
                 )
                 .long_flag_alias("result"),
         )
@@ -257,7 +257,7 @@ fn flag_subcommand_long_with_aliases() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .about("testing testing"),
+                        .help("testing testing"),
                 )
                 .long_flag_aliases(&["result", "someall"]),
         )
@@ -455,7 +455,7 @@ fn flag_subcommand_long_short_normal_usage_string() {
                     Arg::new("search")
                         .short('s')
                         .long("search")
-                        .about("search locally installed packages for matching strings")
+                        .help("search locally installed packages for matching strings")
                         .conflicts_with("info")
                         .takes_value(true)
                         .multiple_values(true),
@@ -465,7 +465,7 @@ fn flag_subcommand_long_short_normal_usage_string() {
                         .long("info")
                         .short('i')
                         .conflicts_with("search")
-                        .about("view package information")
+                        .help("view package information")
                         .takes_value(true)
                         .multiple_values(true),
                 ),
@@ -509,7 +509,7 @@ fn flag_subcommand_long_normal_usage_string() {
                     Arg::new("search")
                         .short('s')
                         .long("search")
-                        .about("search locally installed packages for matching strings")
+                        .help("search locally installed packages for matching strings")
                         .conflicts_with("info")
                         .takes_value(true)
                         .multiple_values(true),
@@ -519,7 +519,7 @@ fn flag_subcommand_long_normal_usage_string() {
                         .long("info")
                         .short('i')
                         .conflicts_with("search")
-                        .about("view package information")
+                        .help("view package information")
                         .takes_value(true)
                         .multiple_values(true),
                 ),
@@ -563,7 +563,7 @@ fn flag_subcommand_short_normal_usage_string() {
                     Arg::new("search")
                         .short('s')
                         .long("search")
-                        .about("search locally installed packages for matching strings")
+                        .help("search locally installed packages for matching strings")
                         .conflicts_with("info")
                         .takes_value(true)
                         .multiple_values(true),
@@ -573,7 +573,7 @@ fn flag_subcommand_short_normal_usage_string() {
                         .long("info")
                         .short('i')
                         .conflicts_with("search")
-                        .about("view package information")
+                        .help("view package information")
                         .takes_value(true)
                         .multiple_values(true),
                 ),

--- a/tests/global_args.rs
+++ b/tests/global_args.rs
@@ -8,7 +8,7 @@ fn issue_1076() {
         .arg(
             Arg::new("GLOBAL_ARG")
                 .long("global-arg")
-                .about("Specifies something needed by the subcommands")
+                .help("Specifies something needed by the subcommands")
                 .global(true)
                 .takes_value(true)
                 .default_value("default_value"),
@@ -16,7 +16,7 @@ fn issue_1076() {
         .arg(
             Arg::new("GLOBAL_FLAG")
                 .long("global-flag")
-                .about("Specifies something needed by the subcommands")
+                .help("Specifies something needed by the subcommands")
                 .global(true)
                 .takes_value(true),
         )

--- a/tests/grouped_values.rs
+++ b/tests/grouped_values.rs
@@ -114,7 +114,7 @@ fn grouped_value_positional_arg() {
     let m = App::new("multiple_values")
         .arg(
             Arg::new("pos")
-                .about("multiple positionals")
+                .help("multiple positionals")
                 .takes_value(true)
                 .multiple_values(true),
         )
@@ -131,10 +131,10 @@ fn grouped_value_positional_arg() {
 #[test]
 fn grouped_value_multiple_positional_arg() {
     let m = App::new("multiple_values")
-        .arg(Arg::new("pos1").about("multiple positionals"))
+        .arg(Arg::new("pos1").help("multiple positionals"))
         .arg(
             Arg::new("pos2")
-                .about("multiple positionals")
+                .help("multiple positionals")
                 .takes_value(true)
                 .multiple_values(true),
         )
@@ -151,10 +151,10 @@ fn grouped_value_multiple_positional_arg() {
 #[test]
 fn grouped_value_multiple_positional_arg_last_multiple() {
     let m = App::new("multiple_values")
-        .arg(Arg::new("pos1").about("multiple positionals"))
+        .arg(Arg::new("pos1").help("multiple positionals"))
         .arg(
             Arg::new("pos2")
-                .about("multiple positionals")
+                .help("multiple positionals")
                 .takes_value(true)
                 .multiple_values(true)
                 .last(true),

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -680,13 +680,13 @@ fn req_last_arg_usage() {
         .version("1.0")
         .arg(
             Arg::new("FIRST")
-                .about("First")
+                .help("First")
                 .multiple_values(true)
                 .required(true),
         )
         .arg(
             Arg::new("SECOND")
-                .about("Second")
+                .help("Second")
                 .multiple_values(true)
                 .required(true)
                 .last(true),
@@ -706,33 +706,33 @@ fn args_with_last_usage() {
         .setting(AppSettings::TrailingVarArg)
         .arg(
             Arg::new("verbose")
-                .about("Prints out more stuff.")
+                .help("Prints out more stuff.")
                 .short('v')
                 .long("verbose")
                 .setting(ArgSettings::MultipleOccurrences),
         )
         .arg(
             Arg::new("timeout")
-                .about("Timeout in seconds.")
+                .help("Timeout in seconds.")
                 .short('t')
                 .long("timeout")
                 .value_name("SECONDS"),
         )
         .arg(
             Arg::new("frequency")
-                .about("The sampling frequency.")
+                .help("The sampling frequency.")
                 .short('f')
                 .long("frequency")
                 .value_name("HERTZ"),
         )
         .arg(
             Arg::new("binary path")
-                .about("The path of the binary to be profiled. for a binary.")
+                .help("The path of the binary to be profiled. for a binary.")
                 .value_name("BINFILE"),
         )
         .arg(
             Arg::new("pass through args")
-                .about("Any arguments you wish to pass to the being profiled.")
+                .help("Any arguments you wish to pass to the being profiled.")
                 .setting(ArgSettings::TakesValue)
                 .setting(ArgSettings::MultipleValues)
                 .setting(ArgSettings::Last)
@@ -898,22 +898,22 @@ OPTIONS:
             Arg::new("all")
                 .short('a')
                 .long("all")
-                .about("Also do versioning for private crates (will not be published)"),
+                .help("Also do versioning for private crates (will not be published)"),
         )
         .arg(
             Arg::new("exact")
                 .long("exact")
-                .about("Specify inter dependency version numbers exactly with `=`"),
+                .help("Specify inter dependency version numbers exactly with `=`"),
         )
         .arg(
             Arg::new("no_git_commit")
                 .long("no-git-commit")
-                .about("Do not commit version changes"),
+                .help("Do not commit version changes"),
         )
         .arg(
             Arg::new("no_git_push")
                 .long("no-git-push")
-                .about("Do not push generated commit and tags to git remote"),
+                .help("Do not push generated commit and tags to git remote"),
         );
     assert!(utils::compare_output(
         app,
@@ -947,22 +947,22 @@ OPTIONS:
             Arg::new("all")
                 .short('a')
                 .long("all")
-                .about("Also do versioning for private crates (will not be published)"),
+                .help("Also do versioning for private crates (will not be published)"),
         )
         .arg(
             Arg::new("exact")
                 .long("exact")
-                .about("Specify inter dependency version numbers exactly with `=`"),
+                .help("Specify inter dependency version numbers exactly with `=`"),
         )
         .arg(
             Arg::new("no_git_commit")
                 .long("no-git-commit")
-                .about("Do not commit version changes"),
+                .help("Do not commit version changes"),
         )
         .arg(
             Arg::new("no_git_push")
                 .long("no-git-push")
-                .about("Do not push generated commit and tags to git remote"),
+                .help("Do not push generated commit and tags to git remote"),
         );
     assert!(utils::compare_output(
         app,
@@ -990,7 +990,7 @@ fn issue_626_unicode_cutoff() {
             .short('c')
             .long("cafe")
             .value_name("FILE")
-            .about(
+            .help(
                 "A coffeehouse, coffee shop, or café is an establishment \
                  which primarily serves hot coffee, related coffee beverages \
                  (e.g., café latte, cappuccino, espresso), tea, and other hot \
@@ -1018,7 +1018,7 @@ fn hide_possible_vals() {
                 .long("pos")
                 .value_name("VAL")
                 .possible_values(["fast", "slow"])
-                .about("Some vals")
+                .help("Some vals")
                 .takes_value(true),
         )
         .arg(
@@ -1028,7 +1028,7 @@ fn hide_possible_vals() {
                 .value_name("FILE")
                 .hide_possible_values(true)
                 .possible_values(["fast", "slow"])
-                .about("A coffeehouse, coffee shop, or café.")
+                .help("A coffeehouse, coffee shop, or café.")
                 .takes_value(true),
         );
     assert!(utils::compare_output(
@@ -1050,7 +1050,7 @@ fn hide_single_possible_val() {
                 .value_name("VAL")
                 .possible_values(["fast", "slow"])
                 .possible_value(PossibleValue::new("secret speed").hidden(true))
-                .about("Some vals")
+                .help("Some vals")
                 .takes_value(true),
         )
         .arg(
@@ -1058,7 +1058,7 @@ fn hide_single_possible_val() {
                 .short('c')
                 .long("cafe")
                 .value_name("FILE")
-                .about("A coffeehouse, coffee shop, or café.")
+                .help("A coffeehouse, coffee shop, or café.")
                 .takes_value(true),
         );
     assert!(utils::compare_output(
@@ -1078,7 +1078,7 @@ fn issue_626_panic() {
            .short('c')
            .long("cafe")
            .value_name("FILE")
-           .about("La culture du café est très développée dans de nombreux pays à climat chaud d'Amérique, \
+           .help("La culture du café est très développée dans de nombreux pays à climat chaud d'Amérique, \
            d'Afrique et d'Asie, dans des plantations qui sont cultivées pour les marchés d'exportation. \
            Le café est souvent une contribution majeure aux exportations des régions productrices.")
            .takes_value(true));
@@ -1100,7 +1100,7 @@ fn issue_626_variable_panic() {
                .short('c')
                .long("cafe")
                .value_name("FILE")
-               .about("La culture du café est très développée dans de nombreux pays à climat chaud d'Amérique, \
+               .help("La culture du café est très développée dans de nombreux pays à climat chaud d'Amérique, \
                d'Afrique et d'Asie, dans des plantations qui sont cultivées pour les marchés d'exportation. \
                Le café est souvent une contribution majeure aux exportations des régions productrices.")
                .takes_value(true))
@@ -1124,7 +1124,7 @@ fn wrapping_newline_chars() {
     let app = App::new("ctest")
         .version("0.1")
         .term_width(60)
-        .arg(Arg::new("mode").about(
+        .arg(Arg::new("mode").help(
             "x, max, maximum   20 characters, contains symbols.\n\
              l, long           Copy-friendly, 14 characters, contains symbols.\n\
              m, med, medium    Copy-friendly, 8 characters, contains symbols.\n",
@@ -1142,7 +1142,7 @@ fn old_newline_chars() {
     let app = App::new("ctest").version("0.1").arg(
         Arg::new("mode")
             .short('m')
-            .about("Some help with some wrapping\n(Defaults to something)"),
+            .help("Some help with some wrapping\n(Defaults to something)"),
     );
     assert!(utils::compare_output(
         app,
@@ -1161,7 +1161,7 @@ fn issue_688_hidden_pos_vals() {
 			.term_width(120)
 			.setting(AppSettings::HidePossibleValuesInHelp)
 			.arg(Arg::new("filter")
-				.about("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
+				.help("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
                 images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic, Gaussian, Lanczos3]")
 				.long("filter")
 				.possible_values(filter_values)
@@ -1177,7 +1177,7 @@ fn issue_688_hidden_pos_vals() {
             .version("0.1")
 			.term_width(120)
 			.arg(Arg::new("filter")
-				.about("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
+				.help("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
                 images. The default is Linear (Bilinear).")
 				.long("filter")
 				.possible_values(filter_values)
@@ -1193,7 +1193,7 @@ fn issue_688_hidden_pos_vals() {
             .version("0.1")
 			.term_width(120)
 			.arg(Arg::new("filter")
-				.about("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
+				.help("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
                 images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic, Gaussian, Lanczos3]")
 				.long("filter")
 				.takes_value(true));
@@ -1211,30 +1211,30 @@ fn issue_702_multiple_values() {
         .version("1.0")
         .author("foo")
         .about("bar")
-        .arg(Arg::new("arg1").about("some option"))
+        .arg(Arg::new("arg1").help("some option"))
         .arg(
             Arg::new("arg2")
                 .takes_value(true)
                 .multiple_values(true)
-                .about("some option"),
+                .help("some option"),
         )
         .arg(
             Arg::new("some")
-                .about("some option")
+                .help("some option")
                 .short('s')
                 .long("some")
                 .takes_value(true),
         )
         .arg(
             Arg::new("other")
-                .about("some other option")
+                .help("some other option")
                 .short('o')
                 .long("other")
                 .takes_value(true),
         )
         .arg(
             Arg::new("label")
-                .about("a label")
+                .help("a label")
                 .short('l')
                 .long("label")
                 .multiple_values(true)
@@ -1252,7 +1252,7 @@ fn long_about() {
         .long_about(
             "something really really long, with\nmultiple lines of text\nthat should be displayed",
         )
-        .arg(Arg::new("arg1").about("some option"));
+        .arg(Arg::new("arg1").help("some option"));
     assert!(utils::compare_output(
         app,
         "myapp --help",
@@ -1267,7 +1267,7 @@ fn issue_760() {
         .version("0.1")
         .arg(
             Arg::new("option")
-                .about("tests options")
+                .help("tests options")
                 .short('o')
                 .long("option")
                 .takes_value(true)
@@ -1276,7 +1276,7 @@ fn issue_760() {
         )
         .arg(
             Arg::new("opt")
-                .about("tests options")
+                .help("tests options")
                 .short('O')
                 .long("opt")
                 .takes_value(true),
@@ -1362,7 +1362,7 @@ fn sc_negates_reqs() {
         .version("1.0")
         .setting(AppSettings::SubcommandsNegateReqs)
         .arg("-o, --opt <FILE> 'tests options'")
-        .arg(Arg::new("PATH").about("help"))
+        .arg(Arg::new("PATH").help("help"))
         .subcommand(App::new("test"));
     assert!(utils::compare_output(
         app,
@@ -1394,7 +1394,7 @@ fn args_negate_sc() {
         .setting(AppSettings::ArgsNegateSubcommands)
         .arg("-f, --flag 'testing flags'")
         .arg("-o, --opt [FILE] 'tests options'")
-        .arg(Arg::new("PATH").about("help"))
+        .arg(Arg::new("PATH").help("help"))
         .subcommand(App::new("test"));
     assert!(utils::compare_output(
         app,
@@ -1410,7 +1410,7 @@ fn issue_1046_hidden_scs() {
         .version("1.0")
         .arg("-f, --flag 'testing flags'")
         .arg("-o, --opt [FILE] 'tests options'")
-        .arg(Arg::new("PATH").about("some"))
+        .arg(Arg::new("PATH").help("some"))
         .subcommand(App::new("test").setting(AppSettings::Hidden));
     assert!(utils::compare_output(
         app,
@@ -1504,7 +1504,7 @@ OPTIONS:
 fn override_help_about() {
     let app = App::new("test")
         .version("0.1")
-        .mut_arg("help", |h| h.about("Print help information"));
+        .mut_arg("help", |h| h.help("Print help information"));
 
     assert!(utils::compare_output(
         app.clone(),
@@ -1546,14 +1546,14 @@ fn arg_short_conflict_with_help_mut_arg() {
 fn last_arg_mult_usage() {
     let app = App::new("last")
         .version("0.1")
-        .arg(Arg::new("TARGET").required(true).about("some"))
-        .arg(Arg::new("CORPUS").about("some"))
+        .arg(Arg::new("TARGET").required(true).help("some"))
+        .arg(Arg::new("CORPUS").help("some"))
         .arg(
             Arg::new("ARGS")
                 .takes_value(true)
                 .multiple_values(true)
                 .last(true)
-                .about("some"),
+                .help("some"),
         );
     assert!(utils::compare_output(app, "last --help", LAST_ARG, false));
 }
@@ -1562,15 +1562,15 @@ fn last_arg_mult_usage() {
 fn last_arg_mult_usage_req() {
     let app = App::new("last")
         .version("0.1")
-        .arg(Arg::new("TARGET").required(true).about("some"))
-        .arg(Arg::new("CORPUS").about("some"))
+        .arg(Arg::new("TARGET").required(true).help("some"))
+        .arg(Arg::new("CORPUS").help("some"))
         .arg(
             Arg::new("ARGS")
                 .takes_value(true)
                 .multiple_values(true)
                 .last(true)
                 .required(true)
-                .about("some"),
+                .help("some"),
         );
     assert!(utils::compare_output(
         app,
@@ -1585,15 +1585,15 @@ fn last_arg_mult_usage_req_with_sc() {
     let app = App::new("last")
         .version("0.1")
         .setting(AppSettings::SubcommandsNegateReqs)
-        .arg(Arg::new("TARGET").required(true).about("some"))
-        .arg(Arg::new("CORPUS").about("some"))
+        .arg(Arg::new("TARGET").required(true).help("some"))
+        .arg(Arg::new("CORPUS").help("some"))
         .arg(
             Arg::new("ARGS")
                 .takes_value(true)
                 .multiple_values(true)
                 .last(true)
                 .required(true)
-                .about("some"),
+                .help("some"),
         )
         .subcommand(App::new("test").about("some"));
     assert!(utils::compare_output(
@@ -1609,14 +1609,14 @@ fn last_arg_mult_usage_with_sc() {
     let app = App::new("last")
         .version("0.1")
         .setting(AppSettings::ArgsNegateSubcommands)
-        .arg(Arg::new("TARGET").required(true).about("some"))
-        .arg(Arg::new("CORPUS").about("some"))
+        .arg(Arg::new("TARGET").required(true).help("some"))
+        .arg(Arg::new("CORPUS").help("some"))
         .arg(
             Arg::new("ARGS")
                 .takes_value(true)
                 .multiple_values(true)
                 .last(true)
-                .about("some"),
+                .help("some"),
         )
         .subcommand(App::new("test").about("some"));
     assert!(utils::compare_output(
@@ -1631,7 +1631,7 @@ fn last_arg_mult_usage_with_sc() {
 fn hidden_default_val() {
     let app1 = App::new("default").version("0.1").term_width(120).arg(
         Arg::new("argument")
-            .about("Pass an argument to the program. [default: default-argument]")
+            .help("Pass an argument to the program. [default: default-argument]")
             .long("arg")
             .default_value("default-argument")
             .hide_default_value(true),
@@ -1645,7 +1645,7 @@ fn hidden_default_val() {
 
     let app2 = App::new("default").version("0.1").term_width(120).arg(
         Arg::new("argument")
-            .about("Pass an argument to the program.")
+            .help("Pass an argument to the program.")
             .long("arg")
             .default_value("default-argument"),
     );
@@ -1661,7 +1661,7 @@ fn hidden_default_val() {
 fn escaped_whitespace_values() {
     let app1 = App::new("default").version("0.1").term_width(120).arg(
         Arg::new("argument")
-            .about("Pass an argument to the program.")
+            .help("Pass an argument to the program.")
             .long("arg")
             .default_value("\n")
             .possible_values(["normal", " ", "\n", "\t", "other"]),
@@ -1677,9 +1677,9 @@ fn escaped_whitespace_values() {
 fn issue_1112_setup() -> App<'static> {
     App::new("test")
         .version("1.3")
-        .arg(Arg::new("help1").long("help").short('h').about("some help"))
+        .arg(Arg::new("help1").long("help").short('h').help("some help"))
         .subcommand(
-            App::new("foo").arg(Arg::new("help1").long("help").short('h').about("some help")),
+            App::new("foo").arg(Arg::new("help1").long("help").short('h').help("some help")),
         )
 }
 
@@ -1763,7 +1763,7 @@ fn custom_headers_headers() {
             Arg::new("no-proxy")
                 .short('n')
                 .long("no-proxy")
-                .about("Do not use system proxy settings"),
+                .help("Do not use system proxy settings"),
         )
         .args(&[Arg::new("port").long("port")]);
 
@@ -1820,7 +1820,7 @@ fn multiple_custom_help_headers() {
             Arg::new("no-proxy")
                 .short('n')
                 .long("no-proxy")
-                .about("Do not use system proxy settings"),
+                .help("Do not use system proxy settings"),
         )
         .help_heading(Some("SPECIAL"))
         .arg(
@@ -1840,7 +1840,7 @@ fn multiple_custom_help_headers() {
             Arg::new("server-addr")
                 .short('a')
                 .long("server-addr")
-                .about("Set server address")
+                .help("Set server address")
                 .help_heading(Some("NETWORKING")),
         )
         .arg(
@@ -1849,7 +1849,7 @@ fn multiple_custom_help_headers() {
                 .short('s')
                 .value_name("SPEED")
                 .possible_values(["fast", "slow"])
-                .about("How fast?")
+                .help("How fast?")
                 .takes_value(true),
         );
 
@@ -1892,7 +1892,7 @@ fn custom_help_headers_hidden_args() {
             Arg::new("no-proxy")
                 .short('n')
                 .long("no-proxy")
-                .about("Do not use system proxy settings")
+                .help("Do not use system proxy settings")
                 .hidden_short_help(true),
         )
         .help_heading(Some("SPECIAL"))
@@ -1908,7 +1908,7 @@ fn custom_help_headers_hidden_args() {
             Arg::new("server-addr")
                 .short('a')
                 .long("server-addr")
-                .about("Set server address")
+                .help("Set server address")
                 .help_heading(Some("NETWORKING"))
                 .hidden_short_help(true),
         );
@@ -2041,7 +2041,7 @@ fn help_required_but_not_given_for_one_of_two_arguments() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
         .arg(Arg::new("foo"))
-        .arg(Arg::new("bar").about("It does bar stuff"))
+        .arg(Arg::new("bar").help("It does bar stuff"))
         .get_matches_from(empty_args());
 }
 
@@ -2049,10 +2049,10 @@ fn help_required_but_not_given_for_one_of_two_arguments() {
 fn help_required_locally_but_not_given_for_subcommand() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
-        .arg(Arg::new("foo").about("It does foo stuff"))
+        .arg(Arg::new("foo").help("It does foo stuff"))
         .subcommand(
             App::new("bar")
-                .arg(Arg::new("create").about("creates bar"))
+                .arg(Arg::new("create").help("creates bar"))
                 .arg(Arg::new("delete")),
         )
         .get_matches_from(empty_args());
@@ -2064,10 +2064,10 @@ fn help_required_locally_but_not_given_for_subcommand() {
 fn help_required_globally_but_not_given_for_subcommand() {
     App::new("myapp")
         .global_setting(AppSettings::HelpRequired)
-        .arg(Arg::new("foo").about("It does foo stuff"))
+        .arg(Arg::new("foo").help("It does foo stuff"))
         .subcommand(
             App::new("bar")
-                .arg(Arg::new("create").about("creates bar"))
+                .arg(Arg::new("create").help("creates bar"))
                 .arg(Arg::new("delete")),
         )
         .get_matches_from(empty_args());
@@ -2077,11 +2077,11 @@ fn help_required_globally_but_not_given_for_subcommand() {
 fn help_required_and_given_for_subcommand() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
-        .arg(Arg::new("foo").about("It does foo stuff"))
+        .arg(Arg::new("foo").help("It does foo stuff"))
         .subcommand(
             App::new("bar")
-                .arg(Arg::new("create").about("creates bar"))
-                .arg(Arg::new("delete").about("deletes bar")),
+                .arg(Arg::new("create").help("creates bar"))
+                .arg(Arg::new("delete").help("deletes bar")),
         )
         .get_matches_from(empty_args());
 }
@@ -2090,7 +2090,7 @@ fn help_required_and_given_for_subcommand() {
 fn help_required_and_given() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
-        .arg(Arg::new("foo").about("It does foo stuff"))
+        .arg(Arg::new("foo").help("It does foo stuff"))
         .get_matches_from(empty_args());
 }
 
@@ -2103,7 +2103,7 @@ fn help_required_and_no_args() {
 
 #[test]
 fn issue_1642_long_help_spacing() {
-    let app = App::new("prog").arg(Arg::new("cfg").long("config").long_about(
+    let app = App::new("prog").arg(Arg::new("cfg").long("config").long_help(
         "The config file used by the myprog must be in JSON format
 with only valid keys and may not contain other nonsense
 that cannot be read by this program. Obviously I'm going on
@@ -2148,13 +2148,13 @@ ARGS:
     <SUBCOMMAND>...    The subcommand whose help message to display
 
 OPTIONS:
-    -h, --help    Print custom help about text
+    -h, --help    Print custom help text
 ";
 
 #[test]
 fn help_subcmd_help() {
     let app = App::new("myapp")
-        .mut_arg("help", |h| h.about("Print custom help about text"))
+        .mut_arg("help", |h| h.help("Print custom help text"))
         .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
 
     assert!(utils::compare_output(
@@ -2176,13 +2176,13 @@ ARGS:
     <SUBCOMMAND>...    The subcommand whose help message to display
 
 OPTIONS:
-    -h, --help    Print custom help about text
+    -h, --help    Print custom help text
 ";
 
 #[test]
 fn subcmd_help_subcmd_help() {
     let app = App::new("myapp")
-        .mut_arg("help", |h| h.about("Print custom help about text"))
+        .mut_arg("help", |h| h.help("Print custom help text"))
         .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
 
     assert!(utils::compare_output(
@@ -2199,7 +2199,7 @@ USAGE:
     myapp subcmd multi
 
 OPTIONS:
-    -h, --help       Print custom help about text
+    -h, --help       Print custom help text
     -V, --version    Print version information
 ";
 
@@ -2209,14 +2209,14 @@ USAGE:
     myapp subcmd multi
 
 OPTIONS:
-    -h, --help       Print custom help about text from multi
+    -h, --help       Print custom help text from multi
     -V, --version    Print version information
 ";
 
 #[test]
 fn help_about_multi_subcmd() {
     let app = App::new("myapp")
-        .mut_arg("help", |h| h.about("Print custom help about text"))
+        .mut_arg("help", |h| h.help("Print custom help text"))
         .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
 
     assert!(utils::compare_output(
@@ -2242,12 +2242,14 @@ fn help_about_multi_subcmd() {
 #[test]
 fn help_about_multi_subcmd_override() {
     let app = App::new("myapp")
-        .mut_arg("help", |h| h.about("Print custom help about text"))
-        .subcommand(App::new("subcmd").subcommand(
-            App::new("multi").version("1.0").mut_arg("help", |h| {
-                h.about("Print custom help about text from multi")
-            }),
-        ));
+        .mut_arg("help", |h| h.help("Print custom help text"))
+        .subcommand(
+            App::new("subcmd").subcommand(
+                App::new("multi")
+                    .version("1.0")
+                    .mut_arg("help", |h| h.help("Print custom help text from multi")),
+            ),
+        );
 
     assert!(utils::compare_output(
         app.clone(),
@@ -2360,9 +2362,9 @@ NETWORKING:
 fn custom_heading_pos() {
     let app = App::new("test")
         .version("1.4")
-        .arg(Arg::new("gear").about("Which gear"))
+        .arg(Arg::new("gear").help("Which gear"))
         .help_heading(Some("NETWORKING"))
-        .arg(Arg::new("speed").about("How fast"));
+        .arg(Arg::new("speed").help("How fast"));
 
     assert!(utils::compare_output(
         app,
@@ -2414,7 +2416,7 @@ fn only_custom_heading_pos_no_args() {
         .setting(AppSettings::DisableVersionFlag)
         .mut_arg("help", |a| a.hidden(true))
         .help_heading(Some("NETWORKING"))
-        .arg(Arg::new("speed").about("How fast"));
+        .arg(Arg::new("speed").help("How fast"));
 
     assert!(utils::compare_output(
         app,

--- a/tests/help_env.rs
+++ b/tests/help_env.rs
@@ -105,7 +105,7 @@ fn hide_env() {
             .value_name("FILE")
             .hide_env(true)
             .env("ENVVAR")
-            .about("A coffeehouse, coffee shop, or café.")
+            .help("A coffeehouse, coffee shop, or café.")
             .takes_value(true),
     );
 
@@ -122,7 +122,7 @@ fn show_env() {
             .long("cafe")
             .value_name("FILE")
             .env("ENVVAR")
-            .about("A coffeehouse, coffee shop, or café.")
+            .help("A coffeehouse, coffee shop, or café.")
             .takes_value(true),
     );
 
@@ -140,7 +140,7 @@ fn hide_env_vals() {
             .value_name("FILE")
             .hide_env_values(true)
             .env("ENVVAR")
-            .about("A coffeehouse, coffee shop, or café.")
+            .help("A coffeehouse, coffee shop, or café.")
             .takes_value(true),
     );
 
@@ -162,7 +162,7 @@ fn show_env_vals() {
             .long("cafe")
             .value_name("FILE")
             .env("ENVVAR")
-            .about("A coffeehouse, coffee shop, or café.")
+            .help("A coffeehouse, coffee shop, or café.")
             .takes_value(true),
     );
 
@@ -184,7 +184,7 @@ fn hide_env_flag() {
             .long("cafe")
             .hide_env(true)
             .env("ENVVAR")
-            .about("A coffeehouse, coffee shop, or café."),
+            .help("A coffeehouse, coffee shop, or café."),
     );
 
     assert!(utils::compare_output(
@@ -204,7 +204,7 @@ fn show_env_flag() {
             .short('c')
             .long("cafe")
             .env("ENVVAR")
-            .about("A coffeehouse, coffee shop, or café."),
+            .help("A coffeehouse, coffee shop, or café."),
     );
 
     assert!(utils::compare_output(
@@ -225,7 +225,7 @@ fn hide_env_vals_flag() {
             .long("cafe")
             .hide_env_values(true)
             .env("ENVVAR")
-            .about("A coffeehouse, coffee shop, or café."),
+            .help("A coffeehouse, coffee shop, or café."),
     );
 
     assert!(utils::compare_output(
@@ -245,7 +245,7 @@ fn show_env_vals_flag() {
             .short('c')
             .long("cafe")
             .env("ENVVAR")
-            .about("A coffeehouse, coffee shop, or café."),
+            .help("A coffeehouse, coffee shop, or café."),
     );
 
     assert!(utils::compare_output(

--- a/tests/hidden_args.rs
+++ b/tests/hidden_args.rs
@@ -88,11 +88,11 @@ fn hidden_short_args() {
                 .short('c')
                 .long("config")
                 .hidden_short_help(true)
-                .about("Some help text describing the --config arg"),
+                .help("Some help text describing the --config arg"),
             Arg::new("visible")
                 .short('v')
                 .long("visible")
-                .about("This text should be visible"),
+                .help("This text should be visible"),
         ]);
 
     assert!(utils::compare_output(
@@ -115,11 +115,11 @@ fn hidden_short_args_long_help() {
                 .short('c')
                 .long("config")
                 .hidden_short_help(true)
-                .about("Some help text describing the --config arg"),
+                .help("Some help text describing the --config arg"),
             Arg::new("visible")
                 .short('v')
                 .long("visible")
-                .about("This text should be visible"),
+                .help("This text should be visible"),
         ]);
 
     assert!(utils::compare_output(
@@ -161,11 +161,11 @@ fn hidden_long_args() {
                 .short('c')
                 .long("config")
                 .hidden_long_help(true)
-                .about("Some help text describing the --config arg"),
+                .help("Some help text describing the --config arg"),
             Arg::new("visible")
                 .short('v')
                 .long("visible")
-                .about("This text should be visible"),
+                .help("This text should be visible"),
         ]);
 
     assert!(utils::compare_output(
@@ -203,11 +203,11 @@ fn hidden_long_args_short_help() {
                 .short('c')
                 .long("config")
                 .hidden_long_help(true)
-                .about("Some help text describing the --config arg"),
+                .help("Some help text describing the --config arg"),
             Arg::new("visible")
                 .short('v')
                 .long("visible")
-                .about("This text should be visible"),
+                .help("This text should be visible"),
         ]);
 
     assert!(utils::compare_output(
@@ -234,8 +234,8 @@ OPTIONS:
 #[test]
 fn hidden_pos_args() {
     let app = App::new("test").version("1.4").args(&[
-        Arg::new("pos").about("some pos").hidden(true),
-        Arg::new("another").about("another pos"),
+        Arg::new("pos").help("some pos").hidden(true),
+        Arg::new("another").help("another pos"),
     ]);
 
     assert!(utils::compare_output(
@@ -310,7 +310,7 @@ fn hidden_pos_args_only() {
         .after_help("After help")
         .mut_arg("help", |a| a.hidden(true))
         .mut_arg("version", |a| a.hidden(true))
-        .args(&[Arg::new("pos").about("some pos").hidden(true)]);
+        .args(&[Arg::new("pos").help("some pos").hidden(true)]);
 
     assert!(utils::compare_output(
         app,

--- a/tests/ignore_errors.rs
+++ b/tests/ignore_errors.rs
@@ -76,14 +76,14 @@ fn subcommand() {
                         .short('t')
                         .long("test")
                         .takes_value(true)
-                        .about("testing testing"),
+                        .help("testing testing"),
                 )
                 .arg(
                     Arg::new("stuff")
                         .short('x')
                         .long("stuff")
                         .takes_value(true)
-                        .about("stuf value"),
+                        .help("stuf value"),
                 ),
         )
         .arg(Arg::new("other").long("other"));

--- a/tests/multiple_values.rs
+++ b/tests/multiple_values.rs
@@ -6,7 +6,7 @@ fn option_long() {
         .arg(
             Arg::new("option")
                 .long("option")
-                .about("multiple options")
+                .help("multiple options")
                 .takes_value(true)
                 .multiple_values(true)
                 .multiple_occurrences(true),
@@ -32,7 +32,7 @@ fn option_short() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .takes_value(true)
                 .multiple_values(true)
                 .multiple_occurrences(true),
@@ -57,7 +57,7 @@ fn option_mixed() {
             Arg::new("option")
                 .long("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .takes_value(true)
                 .multiple_values(true)
                 .multiple_occurrences(true),
@@ -83,7 +83,7 @@ fn option_exact_exact() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .number_of_values(3)
                 .multiple_occurrences(true),
         )
@@ -106,7 +106,7 @@ fn option_exact_exact_not_mult() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .number_of_values(3),
         )
         .try_get_matches_from(vec!["", "-o", "val1", "val2", "val3"]);
@@ -128,7 +128,7 @@ fn option_exact_exact_mult() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .number_of_values(3)
                 .multiple_occurrences(true),
         )
@@ -153,7 +153,7 @@ fn option_exact_less() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .number_of_values(3)
                 .multiple_occurrences(true),
         )
@@ -169,7 +169,7 @@ fn option_exact_more() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .number_of_values(3)
                 .multiple_occurrences(true),
         )
@@ -187,7 +187,7 @@ fn option_min_exact() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .min_values(3)
                 .multiple_occurrences(true),
         )
@@ -210,7 +210,7 @@ fn option_min_less() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .min_values(3)
                 .multiple_occurrences(true),
         )
@@ -227,7 +227,7 @@ fn option_short_min_more_mult_occurs() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .min_values(3)
                 .multiple_occurrences(true),
         )
@@ -255,7 +255,7 @@ fn option_short_min_more_single_occur() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .min_values(3),
         )
         .try_get_matches_from(vec!["", "pos", "-o", "val1", "val2", "val3", "val4"]);
@@ -279,7 +279,7 @@ fn option_max_exact() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .max_values(3)
                 .multiple_occurrences(true),
         )
@@ -302,7 +302,7 @@ fn option_max_less() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .max_values(3)
                 .multiple_occurrences(true),
         )
@@ -325,7 +325,7 @@ fn option_max_more() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .max_values(3)
                 .multiple_occurrences(true),
         )
@@ -342,7 +342,7 @@ fn positional() {
     let m = App::new("multiple_values")
         .arg(
             Arg::new("pos")
-                .about("multiple positionals")
+                .help("multiple positionals")
                 .takes_value(true)
                 .multiple_values(true),
         )
@@ -364,7 +364,7 @@ fn positional_exact_exact() {
     let m = App::new("multiple_values")
         .arg(
             Arg::new("pos")
-                .about("multiple positionals")
+                .help("multiple positionals")
                 .number_of_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3"]);
@@ -385,7 +385,7 @@ fn positional_exact_less() {
     let m = App::new("multiple_values")
         .arg(
             Arg::new("pos")
-                .about("multiple positionals")
+                .help("multiple positionals")
                 .number_of_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2"]);
@@ -399,7 +399,7 @@ fn positional_exact_more() {
     let m = App::new("multiple_values")
         .arg(
             Arg::new("pos")
-                .about("multiple positionals")
+                .help("multiple positionals")
                 .number_of_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3", "val4"]);
@@ -411,7 +411,7 @@ fn positional_exact_more() {
 #[test]
 fn positional_min_exact() {
     let m = App::new("multiple_values")
-        .arg(Arg::new("pos").about("multiple positionals").min_values(3))
+        .arg(Arg::new("pos").help("multiple positionals").min_values(3))
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3"]);
 
     assert!(m.is_ok());
@@ -428,7 +428,7 @@ fn positional_min_exact() {
 #[test]
 fn positional_min_less() {
     let m = App::new("multiple_values")
-        .arg(Arg::new("pos").about("multiple positionals").min_values(3))
+        .arg(Arg::new("pos").help("multiple positionals").min_values(3))
         .try_get_matches_from(vec!["myprog", "val1", "val2"]);
 
     assert!(m.is_err());
@@ -438,7 +438,7 @@ fn positional_min_less() {
 #[test]
 fn positional_min_more() {
     let m = App::new("multiple_values")
-        .arg(Arg::new("pos").about("multiple positionals").min_values(3))
+        .arg(Arg::new("pos").help("multiple positionals").min_values(3))
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3", "val4"]);
 
     assert!(m.is_ok());
@@ -455,7 +455,7 @@ fn positional_min_more() {
 #[test]
 fn positional_max_exact() {
     let m = App::new("multiple_values")
-        .arg(Arg::new("pos").about("multiple positionals").max_values(3))
+        .arg(Arg::new("pos").help("multiple positionals").max_values(3))
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3"]);
 
     assert!(m.is_ok());
@@ -472,7 +472,7 @@ fn positional_max_exact() {
 #[test]
 fn positional_max_less() {
     let m = App::new("multiple_values")
-        .arg(Arg::new("pos").about("multiple positionals").max_values(3))
+        .arg(Arg::new("pos").help("multiple positionals").max_values(3))
         .try_get_matches_from(vec!["myprog", "val1", "val2"]);
 
     assert!(m.is_ok());
@@ -489,7 +489,7 @@ fn positional_max_less() {
 #[test]
 fn positional_max_more() {
     let m = App::new("multiple_values")
-        .arg(Arg::new("pos").about("multiple positionals").max_values(3))
+        .arg(Arg::new("pos").help("multiple positionals").max_values(3))
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3", "val4"]);
 
     assert!(m.is_err());
@@ -502,7 +502,7 @@ fn sep_long_equals() {
         .arg(
             Arg::new("option")
                 .long("option")
-                .about("multiple options")
+                .help("multiple options")
                 .use_delimiter(true),
         )
         .try_get_matches_from(vec!["", "--option=val1,val2,val3"]);
@@ -524,7 +524,7 @@ fn sep_long_space() {
         .arg(
             Arg::new("option")
                 .long("option")
-                .about("multiple options")
+                .help("multiple options")
                 .use_delimiter(true),
         )
         .try_get_matches_from(vec!["", "--option", "val1,val2,val3"]);
@@ -546,7 +546,7 @@ fn sep_short_equals() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .use_delimiter(true),
         )
         .try_get_matches_from(vec!["", "-o=val1,val2,val3"]);
@@ -568,7 +568,7 @@ fn sep_short_space() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .use_delimiter(true),
         )
         .try_get_matches_from(vec!["", "-o", "val1,val2,val3"]);
@@ -590,7 +590,7 @@ fn sep_short_no_space() {
         .arg(
             Arg::new("option")
                 .short('o')
-                .about("multiple options")
+                .help("multiple options")
                 .use_delimiter(true),
         )
         .try_get_matches_from(vec!["", "-oval1,val2,val3"]);
@@ -611,7 +611,7 @@ fn sep_positional() {
     let m = App::new("multiple_values")
         .arg(
             Arg::new("option")
-                .about("multiple options")
+                .help("multiple options")
                 .use_delimiter(true),
         )
         .try_get_matches_from(vec!["", "val1,val2,val3"]);
@@ -633,7 +633,7 @@ fn different_sep() {
         .arg(
             Arg::new("option")
                 .long("option")
-                .about("multiple options")
+                .help("multiple options")
                 .value_delimiter(';'),
         )
         .try_get_matches_from(vec!["", "--option=val1;val2;val3"]);
@@ -654,7 +654,7 @@ fn different_sep_positional() {
     let m = App::new("multiple_values")
         .arg(
             Arg::new("option")
-                .about("multiple options")
+                .help("multiple options")
                 .value_delimiter(';'),
         )
         .try_get_matches_from(vec!["", "val1;val2;val3"]);
@@ -676,7 +676,7 @@ fn no_sep() {
         .arg(
             Arg::new("option")
                 .long("option")
-                .about("multiple options")
+                .help("multiple options")
                 .takes_value(true)
                 .use_delimiter(false),
         )
@@ -695,7 +695,7 @@ fn no_sep_positional() {
     let m = App::new("multiple_values")
         .arg(
             Arg::new("option")
-                .about("multiple options")
+                .help("multiple options")
                 .takes_value(true)
                 .use_delimiter(false),
         )
@@ -1240,7 +1240,7 @@ fn issue_2229() {
     let m = App::new("multiple_values")
         .arg(
             Arg::new("pos")
-                .about("multiple positionals")
+                .help("multiple positionals")
                 .number_of_values(3),
         )
         .try_get_matches_from(vec![

--- a/tests/positionals.rs
+++ b/tests/positionals.rs
@@ -24,7 +24,7 @@ fn issue_946() {
             clap::Arg::new("filter")
                 .index(1)
                 .takes_value(true)
-                .about("filters to apply to output"),
+                .help("filters to apply to output"),
         )
         .try_get_matches_from(vec!["compiletest", "--exact"]);
     assert!(r.is_ok(), "{:#?}", r);
@@ -175,7 +175,7 @@ fn positional_possible_values() {
 #[test]
 fn create_positional() {
     let _ = App::new("test")
-        .arg(Arg::new("test").index(1).about("testing testing"))
+        .arg(Arg::new("test").index(1).help("testing testing"))
         .get_matches_from(vec![""]);
 }
 

--- a/tests/possible_values.rs
+++ b/tests/possible_values.rs
@@ -66,7 +66,7 @@ fn possible_value_arg_value() {
             Arg::new("arg_value").index(1).possible_value(
                 PossibleValue::new("test123")
                     .hidden(false)
-                    .about("It's just a test"),
+                    .help("It's just a test"),
             ),
         )
         .try_get_matches_from(vec!["myprog", "test123"]);

--- a/tests/propagate_globals.rs
+++ b/tests/propagate_globals.rs
@@ -7,7 +7,7 @@ fn get_app() -> App<'static> {
         .arg(
             Arg::new("GLOBAL_ARG")
                 .long("global-arg")
-                .about("Specifies something needed by the subcommands")
+                .help("Specifies something needed by the subcommands")
                 .global(true)
                 .setting(ArgSettings::TakesValue)
                 .default_value("default_value"),
@@ -15,7 +15,7 @@ fn get_app() -> App<'static> {
         .arg(
             Arg::new("GLOBAL_FLAG")
                 .long("global-flag")
-                .about("Specifies something needed by the subcommands")
+                .help("Specifies something needed by the subcommands")
                 .global(true)
                 .setting(ArgSettings::MultipleOccurrences),
         )

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -824,7 +824,7 @@ fn require_eq() {
             .required(true)
             .require_equals(true)
             .value_name("FILE")
-            .about("some"),
+            .help("some"),
     );
     assert!(utils::compare_output(
         app,
@@ -845,7 +845,7 @@ fn require_eq_filtered() {
                 .required(true)
                 .require_equals(true)
                 .value_name("FILE")
-                .about("some"),
+                .help("some"),
         )
         .arg(
             Arg::new("foo")
@@ -854,7 +854,7 @@ fn require_eq_filtered() {
                 .required(true)
                 .require_equals(true)
                 .value_name("FILE")
-                .about("some other arg"),
+                .help("some other arg"),
         );
     assert!(utils::compare_output(
         app,
@@ -875,7 +875,7 @@ fn require_eq_filtered_group() {
                 .required(true)
                 .require_equals(true)
                 .value_name("FILE")
-                .about("some"),
+                .help("some"),
         )
         .arg(
             Arg::new("foo")
@@ -884,7 +884,7 @@ fn require_eq_filtered_group() {
                 .required(true)
                 .require_equals(true)
                 .value_name("FILE")
-                .about("some other arg"),
+                .help("some other arg"),
         )
         .arg(
             Arg::new("g1")
@@ -1010,7 +1010,7 @@ fn issue_1643_args_mutually_require_each_other() {
     let app = App::new("test")
         .arg(
             Arg::new("relation_id")
-                .about("The relation id to get the data from")
+                .help("The relation id to get the data from")
                 .long("relation-id")
                 .short('r')
                 .takes_value(true)
@@ -1018,7 +1018,7 @@ fn issue_1643_args_mutually_require_each_other() {
         )
         .arg(
             Arg::new("remote_unit_name")
-                .about("The name of the remote unit to get data from")
+                .help("The name of the remote unit to get data from")
                 .long("remote-unit")
                 .short('u')
                 .takes_value(true)

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -106,7 +106,7 @@ fn subcommand() {
                     .short('t')
                     .long("test")
                     .takes_value(true)
-                    .about("testing testing"),
+                    .help("testing testing"),
             ),
         )
         .arg(Arg::new("other").long("other"))
@@ -127,7 +127,7 @@ fn subcommand_none_given() {
                     .short('t')
                     .long("test")
                     .takes_value(true)
-                    .about("testing testing"),
+                    .help("testing testing"),
             ),
         )
         .arg(Arg::new("other").long("other"))
@@ -145,7 +145,7 @@ fn subcommand_multiple() {
                     .short('t')
                     .long("test")
                     .takes_value(true)
-                    .about("testing testing"),
+                    .help("testing testing"),
             ),
             App::new("add").arg(Arg::new("roster").short('r')),
         ])

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -159,7 +159,7 @@ OPTIONS:
 #[test]
 fn version_about_multi_subcmd() {
     let app = with_subcommand()
-        .mut_arg("version", |a| a.about("Print custom version about text"))
+        .mut_arg("version", |a| a.help("Print custom version about text"))
         .global_setting(AppSettings::PropagateVersion);
 
     assert!(utils::compare_output(


### PR DESCRIPTION
This reverts commits 24cb8b1..d0abb37 from clap-rs/clap#1840

This is part of #16.  clap-rs/clap#1840 wasn't the right call but we
don't have time to make the decision now, so instead of having one
option and changing it in 4.0, this reverts back to clap2 behavior.