### PR TITLE
fix: Rename App's AllowLeadingHyphen to AllowHyphenValues

### DIFF
--- a/clap_derive/tests/non_literal_attributes.rs
+++ b/clap_derive/tests/non_literal_attributes.rs
@@ -19,7 +19,7 @@ pub const DISPLAY_ORDER: usize = 2;
 
 // Check if the global settings compile
 #[derive(Parser, Debug, PartialEq, Eq)]
-#[clap(global_setting = AppSettings::AllowLeadingHyphen)]
+#[clap(global_setting = AppSettings::AllowHyphenValues)]
 struct Opt {
     #[clap(
         long = "x",

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -77,6 +77,8 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::NO_OP,
     AllowInvalidUtf8ForExternalSubcommands("allowinvalidutf8forexternalsubcommands")
         => Flags::SC_UTF8_NONE,
+    AllowHyphenValues("allowhyphenvalues")
+        => Flags::LEADING_HYPHEN,
     AllowLeadingHyphen("allowleadinghyphen")
         => Flags::LEADING_HYPHEN,
     AllowNegativeNumbers("allownegativenumbers")
@@ -225,7 +227,7 @@ pub enum AppSettings {
     /// # use clap::{Arg, App, AppSettings};
     /// // Imagine you needed to represent negative numbers as well, such as -10
     /// let m = App::new("nums")
-    ///     .setting(AppSettings::AllowLeadingHyphen)
+    ///     .setting(AppSettings::AllowHyphenValues)
     ///     .arg(Arg::new("neg"))
     ///     .get_matches_from(vec![
     ///         "nums", "-20"
@@ -235,6 +237,13 @@ pub enum AppSettings {
     /// # ;
     /// ```
     /// [`Arg::allow_hyphen_values`]: crate::Arg::allow_hyphen_values()
+    AllowHyphenValues,
+
+    /// Deprecated, replaced with [`AppSettings::AllowHyphenValues`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Replaced with `AppSettings::AllowHyphenValues`"
+    )]
     AllowLeadingHyphen,
 
     /// Specifies that all arguments override themselves. This is the equivalent to saying the `foo`
@@ -244,7 +253,7 @@ pub enum AppSettings {
     AllArgsOverrideSelf,
 
     /// Allows negative numbers to pass as values. This is similar to
-    /// [`AppSettings::AllowLeadingHyphen`] except that it only allows numbers, all
+    /// [`AppSettings::AllowHyphenValues`] except that it only allows numbers, all
     /// other undefined leading hyphens will fail to parse.
     ///
     /// # Examples
@@ -1146,8 +1155,8 @@ mod test {
             AppSettings::AllowInvalidUtf8ForExternalSubcommands
         );
         assert_eq!(
-            "allowleadinghyphen".parse::<AppSettings>().unwrap(),
-            AppSettings::AllowLeadingHyphen
+            "allowhyphenvalues".parse::<AppSettings>().unwrap(),
+            AppSettings::AllowHyphenValues
         );
         assert_eq!(
             "allownegativenumbers".parse::<AppSettings>().unwrap(),

--- a/src/build/app/tests.rs
+++ b/src/build/app/tests.rs
@@ -13,7 +13,7 @@ fn propagate_version() {
 #[test]
 fn global_setting() {
     let mut app = App::new("test")
-        .global_setting(AppSettings::AllowLeadingHyphen)
+        .global_setting(AppSettings::AllowHyphenValues)
         .subcommand(App::new("subcmd"));
     app._propagate();
     assert!(app
@@ -21,13 +21,13 @@ fn global_setting() {
         .iter()
         .find(|s| s.name == "subcmd")
         .unwrap()
-        .is_set(AppSettings::AllowLeadingHyphen));
+        .is_set(AppSettings::AllowHyphenValues));
 }
 
 #[test]
 fn global_settings() {
     let mut app = App::new("test")
-        .global_setting(AppSettings::AllowLeadingHyphen)
+        .global_setting(AppSettings::AllowHyphenValues)
         .global_setting(AppSettings::TrailingVarArg)
         .subcommand(App::new("subcmd"));
     app._propagate();
@@ -36,7 +36,7 @@ fn global_settings() {
         .iter()
         .find(|s| s.name == "subcmd")
         .unwrap()
-        .is_set(AppSettings::AllowLeadingHyphen));
+        .is_set(AppSettings::AllowHyphenValues));
     assert!(app
         .subcommands
         .iter()

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -60,6 +60,7 @@ impl_settings! { ArgSettings, ArgFlags,
     RequireDelimiter("requiredelimiter") => Flags::REQ_DELIM,
     HidePossibleValues("hidepossiblevalues") => Flags::HIDE_POS_VALS,
     AllowHyphenValues("allowhyphenvalues") => Flags::ALLOW_TAC_VALS,
+    AllowLeadingHyphen("allowleadinghypyhen") => Flags::ALLOW_TAC_VALS,
     RequireEquals("requireequals") => Flags::REQUIRE_EQUALS,
     Last("last") => Flags::LAST,
     IgnoreCase("ignorecase") => Flags::CASE_INSENSITIVE,
@@ -121,6 +122,12 @@ pub enum ArgSettings {
     HidePossibleValues,
     /// Allows values that start with a hyphen
     AllowHyphenValues,
+    /// Deprecated, replaced with [`ArgSettings::AllowHyphenValues`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Replaced with `ArgSettings::AllowHyphenValues`"
+    )]
+    AllowLeadingHyphen,
     /// Requires that an equals be used to provide a value to an option such as `--option=value`
     RequireEquals,
     /// Says that a positional arg will be the last positional, and requires `--` to be accessed.

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -547,7 +547,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                 } else if let Some(short_arg) = arg_os.strip_prefix("-") {
                     // Arg looks like a short flag, and not a possible number
 
-                    // Try to parse short args like normal, if AllowLeadingHyphen or
+                    // Try to parse short args like normal, if AllowHyphenValues or
                     // AllowNegativeNumbers is set, parse_short_arg will *not* throw
                     // an error, and instead return Ok(None)
                     let parse_result = self.parse_short_arg(
@@ -949,7 +949,7 @@ impl<'help, 'app> Parser<'help, 'app> {
             next, current_positional.name
         );
 
-        if self.is_set(AS::AllowLeadingHyphen)
+        if self.is_set(AS::AllowHyphenValues)
             || self.app[&current_positional.id].is_set(ArgSettings::AllowHyphenValues)
             || (self.is_set(AS::AllowNegativeNumbers) && next.to_str_lossy().parse::<f64>().is_ok())
         {
@@ -1235,7 +1235,7 @@ impl<'help, 'app> Parser<'help, 'app> {
             }
         } else if let Some(sc_name) = self.possible_long_flag_subcommand(arg) {
             ParseResult::FlagSubCommand(sc_name.to_string())
-        } else if self.is_set(AS::AllowLeadingHyphen) {
+        } else if self.is_set(AS::AllowHyphenValues) {
             ParseResult::MaybeHyphenValue
         } else {
             ParseResult::NoMatchingArg {
@@ -1258,7 +1258,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         let arg = short_arg.to_str_lossy();
 
         if (self.is_set(AS::AllowNegativeNumbers) && arg.parse::<f64>().is_ok())
-            || (self.is_set(AS::AllowLeadingHyphen)
+            || (self.is_set(AS::AllowHyphenValues)
                 && arg.chars().any(|c| !self.app.contains_short(c)))
             || matches!(parse_state, ParseState::Opt(opt) | ParseState::Pos(opt)
                 if self.app[opt].is_set(ArgSettings::AllowHyphenValues))

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -539,7 +539,7 @@ fn delim_values_trailingvararg_with_delim() {
 #[test]
 fn leading_hyphen_short() {
     let res = App::new("leadhy")
-        .setting(AppSettings::AllowLeadingHyphen)
+        .setting(AppSettings::AllowHyphenValues)
         .arg(Arg::new("some"))
         .arg(Arg::new("other").short('o'))
         .try_get_matches_from(vec!["", "-bar", "-o"]);
@@ -553,7 +553,7 @@ fn leading_hyphen_short() {
 #[test]
 fn leading_hyphen_long() {
     let res = App::new("leadhy")
-        .setting(AppSettings::AllowLeadingHyphen)
+        .setting(AppSettings::AllowHyphenValues)
         .arg(Arg::new("some"))
         .arg(Arg::new("other").short('o'))
         .try_get_matches_from(vec!["", "--bar", "-o"]);
@@ -567,7 +567,7 @@ fn leading_hyphen_long() {
 #[test]
 fn leading_hyphen_opt() {
     let res = App::new("leadhy")
-        .setting(AppSettings::AllowLeadingHyphen)
+        .setting(AppSettings::AllowHyphenValues)
         .arg(Arg::new("some").takes_value(true).long("opt"))
         .arg(Arg::new("other").short('o'))
         .try_get_matches_from(vec!["", "--opt", "--bar", "-o"]);
@@ -606,7 +606,7 @@ fn allow_negative_numbers_fail() {
 fn leading_double_hyphen_trailingvararg() {
     let m = App::new("positional")
         .setting(AppSettings::TrailingVarArg)
-        .setting(AppSettings::AllowLeadingHyphen)
+        .setting(AppSettings::AllowHyphenValues)
         .arg(arg!([opt] ... "some pos"))
         .get_matches_from(vec!["", "--foo", "-Wl", "bar"]);
     assert!(m.is_present("opt"));
@@ -823,7 +823,7 @@ fn missing_positional_hyphen_req_error() {
 #[test]
 fn issue_1066_allow_leading_hyphen_and_unknown_args() {
     let res = App::new("prog")
-        .global_setting(AppSettings::AllowLeadingHyphen)
+        .global_setting(AppSettings::AllowHyphenValues)
         .arg(arg!(--"some-argument"))
         .try_get_matches_from(vec!["prog", "hello"]);
 
@@ -834,7 +834,7 @@ fn issue_1066_allow_leading_hyphen_and_unknown_args() {
 #[test]
 fn issue_1066_allow_leading_hyphen_and_unknown_args_no_vals() {
     let res = App::new("prog")
-        .global_setting(AppSettings::AllowLeadingHyphen)
+        .global_setting(AppSettings::AllowHyphenValues)
         .arg(arg!(--"some-argument"))
         .try_get_matches_from(vec!["prog", "--hello"]);
 
@@ -845,7 +845,7 @@ fn issue_1066_allow_leading_hyphen_and_unknown_args_no_vals() {
 #[test]
 fn issue_1066_allow_leading_hyphen_and_unknown_args_option() {
     let res = App::new("prog")
-        .global_setting(AppSettings::AllowLeadingHyphen)
+        .global_setting(AppSettings::AllowHyphenValues)
         .arg(arg!(--"some-argument" <val>))
         .try_get_matches_from(vec!["prog", "-hello"]);
 

--- a/tests/positionals.rs
+++ b/tests/positionals.rs
@@ -15,7 +15,7 @@ fn only_pos_follow() {
 #[test]
 fn issue_946() {
     let r = App::new("compiletest")
-        .setting(clap::AppSettings::AllowLeadingHyphen)
+        .setting(clap::AppSettings::AllowHyphenValues)
         .arg(arg!(--exact    "filters match exactly"))
         .arg(
             clap::Arg::new("filter")


### PR DESCRIPTION


This aligns us with `Arg::allow_hyphen_values` in clap2.