### PR TITLE
fix!: Lighten clap's default feature set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,28 +43,24 @@ features = ["doc"]
 [features]
 default = [
 	"std",
-	"derive",
-	"cargo",
 	"color",
-	"env",
 	"suggestions",
-	"unicode",
 ]
 debug = ["clap_derive/debug", "backtrace"] # Enables debug messages
 doc = ["yaml", "regex", "unstable-replace", "unstable-multicall", "unstable-grouped"] # for docs.rs
 
 # Used in default
 std = ["indexmap/std"] # support for no_std in a backwards-compatible way
-derive = ["clap_derive", "lazy_static"]
-cargo = ["lazy_static"] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros
 color = ["atty", "termcolor"]
-env = [] # Use environment variables during arg parsing
 suggestions = ["strsim"]
-unicode = ["textwrap/unicode-width", "unicase"]  # Support for unicode characters in arguments and help messages
 
 # Optional
+derive = ["clap_derive", "lazy_static"]
+cargo = ["lazy_static"] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros
 wrap_help = ["terminal_size", "textwrap/terminal_size"]
 yaml = ["yaml-rust"]
+env = [] # Use environment variables during arg parsing
+unicode = ["textwrap/unicode-width", "unicase"]  # Support for unicode characters in arguments and help messages
 
 # In-work features
 unstable-replace = []

--- a/README.md
+++ b/README.md
@@ -371,12 +371,8 @@ Disabling optional features can decrease the binary size of `clap` and decrease 
 #### Features enabled by default
 
 * **std**: _Not Currently Used._ Placeholder for supporting `no_std` environments in a backwards compatible manner.
-* **derive**: Enables the custom derive (i.e. `#[derive(Parser)]`). Without this you must use one of the other methods of creating a `clap` CLI listed above. (builds dependency `clap_derive`)
-* **cargo**: Turns on macros that read values from `CARGO_*` environment variables.
 * **color**: Turns on colored error messages. (builds dependency `atty`, `termcolor`)
-* **env**: Turns on the usage of environment variables during parsing.
 * **suggestions**: Turns on the `Did you mean '--myoption'?` feature for when users make typos. (builds dependency `strsim`)
-* **unicode**: Turns on support for unicode characters in arguments and help messages. (builds dependency `textwrap`, `unicase`)
 
 To disable these, add this to your `Cargo.toml`:
 
@@ -395,14 +391,17 @@ version = "3.0.0-beta.5"
 default-features = false
 
 # Cherry-pick the features you'd like to use
-features = ["std", "suggestions", "color"]
+features = ["std", "suggestions"]
 ```
 
 #### Opt-in features
 
+* **derive**: Enables the custom derive (i.e. `#[derive(Parser)]`). Without this you must use one of the other methods of creating a `clap` CLI listed above. (builds dependency `clap_derive`)
+* **cargo**: Turns on macros that read values from `CARGO_*` environment variables.
+* **env**: Turns on the usage of environment variables during parsing.
 * **regex**: Enables regex validators. (builds dependency `regex`)
+* **unicode**: Turns on support for unicode characters (including emoji) in arguments and help messages. (builds dependency `textwrap`, `unicase`)
 * **wrap_help**: Turns on the help text wrapping feature, based on the terminal size. (builds dependency `term-size`)
-* **yaml**: Enables building CLIs from YAML documents. (builds dependency `yaml-rust`)
 
 #### Experimental features
 


### PR DESCRIPTION
Too many times people have to disable default features.  Let's try to
have a more minimal out of box experience.

- `derive`: people are already used to adding this feature for serde
- `cargo`: not needed for derive
- `env`: most probably don't use this
- `unicode`: most CLIs are probably ASCII.  We should do a debug warn
  about this though

BREAKING CHANGE: `derive`, `cargo`, `env`, and `unicode` are no longer
on by default.