### PR TITLE
Color debug output

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -805,8 +805,13 @@ macro_rules! wlnerr {
 #[cfg(feature = "debug")]
 macro_rules! debug {
     ($($arg:tt)*) => ({
-        print!("[{:>w$}] \t", module_path!(), w = 28);
-        println!($($arg)*);
+        let prefix = format!("[{:>w$}] \t", module_path!(), w = 28);
+        let body = format!($($arg)*);
+        let mut color = $crate::output::fmt::Colorizer::new(true, $crate::ColorChoice::Auto);
+        color.hint(prefix);
+        color.hint(body);
+        color.none("\n");
+        let _ = color.print();
     })
 }
 

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -38,6 +38,12 @@ impl Colorizer {
     }
 
     #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn hint(&mut self, msg: impl Into<String>) {
+        self.pieces.push((msg.into(), Style::Hint));
+    }
+
+    #[inline]
     pub(crate) fn none(&mut self, msg: impl Into<String>) {
         self.pieces.push((msg.into(), Style::Default));
     }
@@ -75,6 +81,9 @@ impl Colorizer {
                 Style::Error => {
                     color.set_fg(Some(termcolor::Color::Red));
                     color.set_bold(true);
+                }
+                Style::Hint => {
+                    color.set_dimmed(true);
                 }
                 Style::Default => {}
             }
@@ -119,6 +128,7 @@ pub enum Style {
     Good,
     Warning,
     Error,
+    Hint,
     Default,
 }
 
@@ -130,8 +140,6 @@ impl Default for Style {
 
 #[cfg(feature = "color")]
 fn is_a_tty(stderr: bool) -> bool {
-    debug!("is_a_tty: stderr={:?}", stderr);
-
     let stream = if stderr {
         atty::Stream::Stderr
     } else {

--- a/src/util/color.rs
+++ b/src/util/color.rs
@@ -60,14 +60,3 @@ impl Default for ColorChoice {
         Self::Auto
     }
 }
-
-#[cfg(feature = "color")]
-pub(crate) use termcolor::Color;
-
-#[cfg(not(feature = "color"))]
-#[derive(Copy, Clone, Debug)]
-pub(crate) enum Color {
-    Green,
-    Yellow,
-    Red,
-}


### PR DESCRIPTION
This started as a journey to add warnings for non-ascii characters when the `unicode` feature is disabled, as part of #27.  While helpful, there was a lot to write and I gave up on it.  We at least have this now.