### PR TITLE
fix: Rename HelpRequired to HelpExpected

### DIFF
--- a/src/build/app/debug_asserts.rs
+++ b/src/build/app/debug_asserts.rs
@@ -297,7 +297,7 @@ pub(crate) fn assert_app(app: &App) {
         );
     }
 
-    app._panic_on_missing_help(app.g_settings.is_set(AppSettings::HelpRequired));
+    app._panic_on_missing_help(app.g_settings.is_set(AppSettings::HelpExpected));
     assert_app_flags(app);
 }
 

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2551,7 +2551,7 @@ impl<'help> App<'help> {
     }
 
     fn _panic_on_missing_help(&self, help_required_globally: bool) {
-        if self.is_set(AppSettings::HelpRequired) || help_required_globally {
+        if self.is_set(AppSettings::HelpExpected) || help_required_globally {
             let args_missing_help: Vec<String> = self
                 .args
                 .args()
@@ -2560,7 +2560,7 @@ impl<'help> App<'help> {
                 .collect();
 
             assert!(args_missing_help.is_empty(),
-                    "AppSettings::HelpRequired is enabled for the App {}, but at least one of its arguments does not have either `help` or `long_help` set. List of such arguments: {}",
+                    "AppSettings::HelpExpected is enabled for the App {}, but at least one of its arguments does not have either `help` or `long_help` set. List of such arguments: {}",
                     self.name,
                     args_missing_help.join(", ")
                 );

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -115,7 +115,7 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::PROPAGATE_VERSION,
     HidePossibleValuesInHelp("hidepossiblevaluesinhelp")
         => Flags::NO_POS_VALUES,
-    HelpRequired("helprequired")
+    HelpExpected("helpexpected")
         => Flags::HELP_REQUIRED,
     Hidden("hidden")
         => Flags::HIDDEN,
@@ -785,10 +785,10 @@ pub enum AppSettings {
     /// ```rust
     /// # use clap::{App, Arg, AppSettings};
     /// App::new("myprog")
-    ///     .setting(AppSettings::HelpRequired)
+    ///     .setting(AppSettings::HelpExpected)
     ///     .arg(
     ///         Arg::new("foo").help("It does foo stuff")
-    ///         // As required via AppSettings::HelpRequired, a help message was supplied
+    ///         // As required via AppSettings::HelpExpected, a help message was supplied
     ///      )
     /// #    .get_matches();
     /// ```
@@ -798,16 +798,16 @@ pub enum AppSettings {
     /// ```rust,no_run
     /// # use clap::{App, Arg, AppSettings};
     /// App::new("myapp")
-    ///     .setting(AppSettings::HelpRequired)
+    ///     .setting(AppSettings::HelpExpected)
     ///     .arg(
     ///         Arg::new("foo")
     ///         // Someone forgot to put .about("...") here
-    ///         // Since the setting AppSettings::HelpRequired is activated, this will lead to
+    ///         // Since the setting AppSettings::HelpExpected is activated, this will lead to
     ///         // a panic (if you are in debug mode)
     ///     )
     /// #   .get_matches();
     ///```
-    HelpRequired,
+    HelpExpected,
 
     /// Try not to fail on parse errors like missing option values.
     ///
@@ -1195,8 +1195,8 @@ mod test {
             AppSettings::HidePossibleValuesInHelp
         );
         assert_eq!(
-            "helprequired".parse::<AppSettings>().unwrap(),
-            AppSettings::HelpRequired
+            "helpexpected".parse::<AppSettings>().unwrap(),
+            AppSettings::HelpExpected
         );
         assert_eq!(
             "nobinaryname".parse::<AppSettings>().unwrap(),

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -2031,30 +2031,30 @@ fn issue_1487() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "AppSettings::HelpRequired is enabled for the App"]
+#[should_panic = "AppSettings::HelpExpected is enabled for the App"]
 fn help_required_but_not_given() {
     App::new("myapp")
-        .setting(AppSettings::HelpRequired)
+        .setting(AppSettings::HelpExpected)
         .arg(Arg::new("foo"))
         .get_matches_from(empty_args());
 }
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "AppSettings::HelpRequired is enabled for the App"]
+#[should_panic = "AppSettings::HelpExpected is enabled for the App"]
 fn help_required_but_not_given_settings_after_args() {
     App::new("myapp")
         .arg(Arg::new("foo"))
-        .setting(AppSettings::HelpRequired)
+        .setting(AppSettings::HelpExpected)
         .get_matches_from(empty_args());
 }
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "AppSettings::HelpRequired is enabled for the App"]
+#[should_panic = "AppSettings::HelpExpected is enabled for the App"]
 fn help_required_but_not_given_for_one_of_two_arguments() {
     App::new("myapp")
-        .setting(AppSettings::HelpRequired)
+        .setting(AppSettings::HelpExpected)
         .arg(Arg::new("foo"))
         .arg(Arg::new("bar").help("It does bar stuff"))
         .get_matches_from(empty_args());
@@ -2063,7 +2063,7 @@ fn help_required_but_not_given_for_one_of_two_arguments() {
 #[test]
 fn help_required_locally_but_not_given_for_subcommand() {
     App::new("myapp")
-        .setting(AppSettings::HelpRequired)
+        .setting(AppSettings::HelpExpected)
         .arg(Arg::new("foo").help("It does foo stuff"))
         .subcommand(
             App::new("bar")
@@ -2075,10 +2075,10 @@ fn help_required_locally_but_not_given_for_subcommand() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "AppSettings::HelpRequired is enabled for the App"]
+#[should_panic = "AppSettings::HelpExpected is enabled for the App"]
 fn help_required_globally_but_not_given_for_subcommand() {
     App::new("myapp")
-        .global_setting(AppSettings::HelpRequired)
+        .global_setting(AppSettings::HelpExpected)
         .arg(Arg::new("foo").help("It does foo stuff"))
         .subcommand(
             App::new("bar")
@@ -2091,7 +2091,7 @@ fn help_required_globally_but_not_given_for_subcommand() {
 #[test]
 fn help_required_and_given_for_subcommand() {
     App::new("myapp")
-        .setting(AppSettings::HelpRequired)
+        .setting(AppSettings::HelpExpected)
         .arg(Arg::new("foo").help("It does foo stuff"))
         .subcommand(
             App::new("bar")
@@ -2104,7 +2104,7 @@ fn help_required_and_given_for_subcommand() {
 #[test]
 fn help_required_and_given() {
     App::new("myapp")
-        .setting(AppSettings::HelpRequired)
+        .setting(AppSettings::HelpExpected)
         .arg(Arg::new("foo").help("It does foo stuff"))
         .get_matches_from(empty_args());
 }
@@ -2112,7 +2112,7 @@ fn help_required_and_given() {
 #[test]
 fn help_required_and_no_args() {
     App::new("myapp")
-        .setting(AppSettings::HelpRequired)
+        .setting(AppSettings::HelpExpected)
         .get_matches_from(empty_args());
 }
 


### PR DESCRIPTION
This both distances itself from our 'require' terminology and aligns
itself with `Option::expect`, making it more likely for people to guess
the intended behavior.