### PR TITLE
chore(ci): Verify unicode feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default = [
 	"suggestions",
 ]
 debug = ["clap_derive/debug", "backtrace"] # Enables debug messages
-doc = ["derive", "cargo", "wrap_help", "yaml", "regex", "env", "unstable-replace", "unstable-multicall", "unstable-grouped"] # for docs.rs
+doc = ["derive", "cargo", "wrap_help", "yaml", "env", "unicode", "regex", "unstable-replace", "unstable-multicall", "unstable-grouped"] # for docs.rs
 
 # Used in default
 std = ["indexmap/std"] # support for no_std in a backwards-compatible way

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ endif
 _FEATURES = minimal default wasm full release
 _FEATURES_minimal = --no-default-features --features "std"
 _FEATURES_default =
-_FEATURES_wasm = --features "yaml regex unstable-replace unstable-multicall unstable-grouped"
-_FEATURES_full = --features "wrap_help yaml regex unstable-replace unstable-multicall unstable-grouped doc"
+_FEATURES_wasm = --features "derive cargo env unicode yaml regex unstable-replace unstable-multicall unstable-grouped"
+_FEATURES_full = --features "derive cargo env unicode yaml regex unstable-replace unstable-multicall unstable-grouped wrap_help doc"
 _FEATURES_debug = ${_FEATURES_full} --features debug
 _FEATURES_release = ${_FEATURES_full} --release
 


### PR DESCRIPTION
In #27, we removed some default features.  When doing so, some places
weren't updated but `doc` feature covered it ... except it was only
partially updated.  This makes sure we test all the features.