### PR TITLE
fix: Change `app_from_crate` default separator

### DIFF
--- a/examples/09_cargo_metadata.md
+++ b/examples/09_cargo_metadata.md
@@ -5,7 +5,7 @@ You can have clap pull the application metadata directly from your Cargo.toml us
 $ 09_cargo_metadata --help
 clap 3.0.0-beta.5
 
-Kevin K. <kbknapp@gmail.com>:Clap Maintainers
+Kevin K. <kbknapp@gmail.com>, Clap Maintainers
 
 A simple to use, efficient, and full-featured Command Line Argument Parser
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -144,7 +144,7 @@ macro_rules! app_from_crate {
     () => {
         $crate::App::new($crate::crate_name!())
             .version($crate::crate_version!())
-            .author($crate::crate_authors!())
+            .author($crate::crate_authors!(", "))
             .about($crate::crate_description!())
     };
     ($sep:expr) => {

--- a/tests/builder/app_from_crate.rs
+++ b/tests/builder/app_from_crate.rs
@@ -4,7 +4,7 @@ use clap::{app_from_crate, ErrorKind};
 
 static EVERYTHING: &str = "clap {{version}}
 
-Kevin K. <kbknapp@gmail.com>:Clap Maintainers
+Kevin K. <kbknapp@gmail.com>, Clap Maintainers
 
 A simple to use, efficient, and full-featured Command Line Argument Parser
 


### PR DESCRIPTION
`":"` isn't ideal, so let's make it at least `"," `.

BREAKING CHANGE: Changed `app_from_crate!()` to use `", "` separator for
authors.