### PR TITLE
fix(derive): Smooth out transition for structopt 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ whether in changes or their motivation.
 
 TBD:
 - `AppSettings::ColoredHelp`: we are now relying solely on the `color` feature flag and `App::color` method
-- Rename of `StructOpt`
-- Rename of `structopt`
 
 ### BREAKING CHANGES
 

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -15,34 +15,13 @@
 use std::env;
 
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::abort_call_site;
 use quote::quote;
-use syn::{Attribute, Data, DataStruct, DeriveInput, Fields, Generics, Ident};
+use syn::{Attribute, Generics, Ident};
 
 use crate::{
     attrs::{Attrs, Name, DEFAULT_CASING, DEFAULT_ENV_CASING},
-    dummies,
     utils::Sp,
 };
-
-pub fn derive_into_app(input: &DeriveInput) -> TokenStream {
-    let ident = &input.ident;
-
-    dummies::into_app(ident);
-
-    match input.data {
-        Data::Struct(DataStruct {
-            fields: Fields::Named(_),
-            ..
-        }) => gen_for_struct(ident, &input.generics, &input.attrs),
-        Data::Struct(DataStruct {
-            fields: Fields::Unit,
-            ..
-        }) => gen_for_struct(ident, &input.generics, &input.attrs),
-        Data::Enum(_) => gen_for_enum(ident, &input.generics, &input.attrs),
-        _ => abort_call_site!("`#[derive(IntoApp)]` only supports non-tuple structs and enums"),
-    }
-}
 
 pub fn gen_for_struct(
     struct_name: &Ident,

--- a/clap_derive/src/derives/mod.rs
+++ b/clap_derive/src/derives/mod.rs
@@ -20,5 +20,4 @@ mod subcommand;
 pub use self::parser::derive_parser;
 pub use arg_enum::derive_arg_enum;
 pub use args::derive_args;
-pub use into_app::derive_into_app;
 pub use subcommand::derive_subcommand;

--- a/clap_derive/src/lib.rs
+++ b/clap_derive/src/lib.rs
@@ -50,14 +50,6 @@ pub fn parser(input: TokenStream) -> TokenStream {
     derives::derive_parser(&input).into()
 }
 
-/// Generates the `IntoApp` impl.
-#[proc_macro_derive(IntoApp, attributes(clap))]
-#[proc_macro_error]
-pub fn into_app(input: TokenStream) -> TokenStream {
-    let input: DeriveInput = parse_macro_input!(input);
-    derives::derive_into_app(&input).into()
-}
-
 /// Generates the `Subcommand` impl.
 #[proc_macro_derive(Subcommand, attributes(clap))]
 #[proc_macro_error]

--- a/clap_derive/src/lib.rs
+++ b/clap_derive/src/lib.rs
@@ -43,7 +43,7 @@ pub fn arg_enum(input: TokenStream) -> TokenStream {
 /// receiving an instance of `clap::ArgMatches` from conducting parsing, and then
 /// implementing a conversion code to instantiate an instance of the user
 /// context struct.
-#[proc_macro_derive(Parser, attributes(clap))]
+#[proc_macro_derive(Parser, attributes(clap, structopt))]
 #[proc_macro_error]
 pub fn parser(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);

--- a/clap_derive/src/parse.rs
+++ b/clap_derive/src/parse.rs
@@ -274,7 +274,7 @@ fn raw_method_suggestion(ts: ParseBuffer) -> String {
 pub fn parse_clap_attributes(all_attrs: &[Attribute]) -> Vec<ClapAttr> {
     all_attrs
         .iter()
-        .filter(|attr| attr.path.is_ident("clap"))
+        .filter(|attr| attr.path.is_ident("clap") || attr.path.is_ident("structopt"))
         .flat_map(|attr| {
             attr.parse_args_with(Punctuated::<ClapAttr, Token![,]>::parse_terminated)
                 .unwrap_or_abort()

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -152,6 +152,73 @@ pub trait Parser: FromArgMatches + IntoApp + Sized {
         <Self as FromArgMatches>::update_from_arg_matches(self, &matches)
             .map_err(format_error::<Self>)
     }
+
+    /// Deprecated, `StructOpt::clap` replaced with [`IntoApp::into_app`] (derive as part of
+    /// [`Parser`])
+    #[deprecated(
+        since = "3.0.0",
+        note = "`StructOpt::clap` is replaced with `IntoApp::into_app` (derived as part of `Parser`)"
+    )]
+    fn clap<'help>() -> App<'help> {
+        <Self as IntoApp>::into_app()
+    }
+
+    /// Deprecated, `StructOpt::from_clap` replaced with [`FromArgMatches::from_arg_matches`] (derive as part of
+    /// [`Parser`])
+    #[deprecated(
+        since = "3.0.0",
+        note = "`StructOpt::clap` is replaced with `IntoApp::into_app` (derived as part of `Parser`)"
+    )]
+    fn from_clap(matches: &ArgMatches) -> Self {
+        <Self as FromArgMatches>::from_arg_matches(matches).unwrap()
+    }
+
+    /// Deprecated, `StructOpt::from_args` replaced with `Parser::parse` (note the change in derives)
+    #[deprecated(
+        since = "3.0.0",
+        note = "`StructOpt::from_args` is replaced with `Parser::parse` (note the change in derives)"
+    )]
+    fn from_args() -> Self {
+        Self::parse()
+    }
+
+    /// Deprecated, `StructOpt::from_args_safe` replaced with `Parser::try_parse` (note the change in derives)
+    #[deprecated(
+        since = "3.0.0",
+        note = "`StructOpt::from_args_safe` is replaced with `Parser::try_parse` (note the change in derives)"
+    )]
+    fn from_args_safe() -> Result<Self, Error> {
+        Self::try_parse()
+    }
+
+    /// Deprecated, `StructOpt::from_iter` replaced with `Parser::parse_from` (note the change in derives)
+    #[deprecated(
+        since = "3.0.0",
+        note = "`StructOpt::from_iter` is replaced with `Parser::parse_from` (note the change in derives)"
+    )]
+    fn from_iter<I, T>(itr: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        // TODO (@CreepySkeleton): discover a way to avoid cloning here
+        T: Into<OsString> + Clone,
+    {
+        Self::parse_from(itr)
+    }
+
+    /// Deprecated, `StructOpt::from_iter_safe` replaced with `Parser::try_parse_from` (note the
+    /// change in derives)
+    #[deprecated(
+        since = "3.0.0",
+        note = "`StructOpt::from_iter_safe` is replaced with `Parser::try_parse_from` (note the change in derives)"
+    )]
+    fn from_iter_safe<I, T>(itr: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = T>,
+        // TODO (@CreepySkeleton): discover a way to avoid cloning here
+        T: Into<OsString> + Clone,
+    {
+        Self::try_parse_from(itr)
+    }
 }
 
 /// Build an [`App`] relevant for a user-defined container.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,10 @@ pub use yaml_rust::YamlLoader;
 #[doc(hidden)]
 pub use clap_derive::{self, *};
 
+/// Deprecated, replaced with [`Parser`]
+#[deprecated(since = "3.0.0", note = "Replaced with `Parser`")]
+pub use Parser as StructOpt;
+
 #[cfg(any(feature = "derive", feature = "cargo"))]
 #[doc(hidden)]
 pub use lazy_static;

--- a/tests/derive/main.rs
+++ b/tests/derive/main.rs
@@ -26,6 +26,7 @@ mod raw_bool_literal;
 mod raw_idents;
 mod rename_all_env;
 mod skip;
+mod structopt;
 mod subcommands;
 mod utf8;
 mod utils;

--- a/tests/derive/structopt.rs
+++ b/tests/derive/structopt.rs
@@ -1,0 +1,22 @@
+use clap::{AppSettings, StructOpt};
+
+#[test]
+fn compatible() {
+    #[derive(StructOpt)]
+    #[structopt(author, version, about)]
+    #[structopt(global_setting(AppSettings::PropagateVersion))]
+    #[structopt(global_setting(AppSettings::UseLongFormatForHelpSubcommand))]
+    struct Cli {
+        #[structopt(subcommand)]
+        command: Commands,
+    }
+
+    #[derive(StructOpt)]
+    #[structopt(setting(AppSettings::SubcommandRequiredElseHelp))]
+    enum Commands {
+        /// Adds files to myapp
+        Add { name: Option<String> },
+    }
+
+    Cli::from_iter(["test", "add"]);
+}

--- a/tests/derive/structopt.rs
+++ b/tests/derive/structopt.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use clap::{AppSettings, StructOpt};
 
 #[test]


### PR DESCRIPTION
Adding in a `StructOpt` derive with `structopt` attributes, with
deprecation notices.  Unofrtunately, not as many deprecation warnings as
I would like.  Apparently, you can't do them for a `use` of a derive?  I
also wanted to inject code that would trigger a deprecation notice for
attributes but that would require enough of a refactor that I didn't
consider it worth it.  We are at least providing a transition window
even if it means we'll have to remvoe it next major release without a
deprecation warning.