### PR TITLE
docs: Re-order items in docs

### DIFF
--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -34,66 +34,6 @@ pub const DEFAULT_CASING: CasingStyle = CasingStyle::Kebab;
 /// Default casing style for environment variables
 pub const DEFAULT_ENV_CASING: CasingStyle = CasingStyle::ScreamingSnake;
 
-#[allow(clippy::large_enum_variant)]
-#[derive(Clone)]
-pub enum Kind {
-    Arg(Sp<Ty>),
-    FromGlobal(Sp<Ty>),
-    Subcommand(Sp<Ty>),
-    Flatten,
-    Skip(Option<Expr>),
-    ExternalSubcommand,
-}
-
-#[derive(Clone)]
-pub struct Method {
-    name: Ident,
-    args: TokenStream,
-}
-
-#[derive(Clone)]
-pub struct Parser {
-    pub kind: Sp<ParserKind>,
-    pub func: TokenStream,
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub enum ParserKind {
-    FromStr,
-    TryFromStr,
-    FromOsStr,
-    TryFromOsStr,
-    FromOccurrences,
-    FromFlag,
-}
-
-/// Defines the casing for the attributes long representation.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum CasingStyle {
-    /// Indicate word boundaries with uppercase letter, excluding the first word.
-    Camel,
-    /// Keep all letters lowercase and indicate word boundaries with hyphens.
-    Kebab,
-    /// Indicate word boundaries with uppercase letter, including the first word.
-    Pascal,
-    /// Keep all letters uppercase and indicate word boundaries with underscores.
-    ScreamingSnake,
-    /// Keep all letters lowercase and indicate word boundaries with underscores.
-    Snake,
-    /// Keep all letters lowercase and remove word boundaries.
-    Lower,
-    /// Keep all letters uppercase and remove word boundaries.
-    Upper,
-    /// Use the original attribute name defined in the code.
-    Verbatim,
-}
-
-#[derive(Clone)]
-pub enum Name {
-    Derived(Ident),
-    Assigned(TokenStream),
-}
-
 #[derive(Clone)]
 pub struct Attrs {
     name: Name,
@@ -112,345 +52,7 @@ pub struct Attrs {
     kind: Sp<Kind>,
 }
 
-impl Method {
-    pub fn new(name: Ident, args: TokenStream) -> Self {
-        Method { name, args }
-    }
-
-    fn from_lit_or_env(ident: Ident, lit: Option<LitStr>, env_var: &str) -> Self {
-        let mut lit = match lit {
-            Some(lit) => lit,
-
-            None => match env::var(env_var) {
-                Ok(val) => LitStr::new(&val, ident.span()),
-                Err(_) => {
-                    abort!(ident,
-                        "cannot derive `{}` from Cargo.toml", ident;
-                        note = "`{}` environment variable is not set", env_var;
-                        help = "use `{} = \"...\"` to set {} manually", ident, ident;
-                    );
-                }
-            },
-        };
-
-        if ident == "author" {
-            let edited = process_author_str(&lit.value());
-            lit = LitStr::new(&edited, lit.span());
-        }
-
-        Method::new(ident, quote!(#lit))
-    }
-}
-
-impl ToTokens for Method {
-    fn to_tokens(&self, ts: &mut proc_macro2::TokenStream) {
-        let Method { ref name, ref args } = self;
-
-        let tokens = quote!( .#name(#args) );
-
-        tokens.to_tokens(ts);
-    }
-}
-
-impl Parser {
-    fn default_spanned(span: Span) -> Sp<Self> {
-        let kind = Sp::new(ParserKind::TryFromStr, span);
-        let func = quote_spanned!(span=> ::std::str::FromStr::from_str);
-        Sp::new(Parser { kind, func }, span)
-    }
-
-    fn from_spec(parse_ident: Ident, spec: ParserSpec) -> Sp<Self> {
-        use self::ParserKind::*;
-
-        let kind = match &*spec.kind.to_string() {
-            "from_str" => FromStr,
-            "try_from_str" => TryFromStr,
-            "from_os_str" => FromOsStr,
-            "try_from_os_str" => TryFromOsStr,
-            "from_occurrences" => FromOccurrences,
-            "from_flag" => FromFlag,
-            s => abort!(spec.kind.span(), "unsupported parser `{}`", s),
-        };
-
-        let func = match spec.parse_func {
-            None => match kind {
-                FromStr | FromOsStr => {
-                    quote_spanned!(spec.kind.span()=> ::std::convert::From::from)
-                }
-                TryFromStr => quote_spanned!(spec.kind.span()=> ::std::str::FromStr::from_str),
-                TryFromOsStr => abort!(
-                    spec.kind.span(),
-                    "you must set parser for `try_from_os_str` explicitly"
-                ),
-                FromOccurrences => quote_spanned!(spec.kind.span()=> { |v| v as _ }),
-                FromFlag => quote_spanned!(spec.kind.span()=> ::std::convert::From::from),
-            },
-
-            Some(func) => match func {
-                Expr::Path(_) => quote!(#func),
-                _ => abort!(func, "`parse` argument must be a function path"),
-            },
-        };
-
-        let kind = Sp::new(kind, spec.kind.span());
-        let parser = Parser { kind, func };
-        Sp::new(parser, parse_ident.span())
-    }
-}
-
-impl CasingStyle {
-    fn from_lit(name: LitStr) -> Sp<Self> {
-        use self::CasingStyle::*;
-
-        let normalized = name.value().to_camel_case().to_lowercase();
-        let cs = |kind| Sp::new(kind, name.span());
-
-        match normalized.as_ref() {
-            "camel" | "camelcase" => cs(Camel),
-            "kebab" | "kebabcase" => cs(Kebab),
-            "pascal" | "pascalcase" => cs(Pascal),
-            "screamingsnake" | "screamingsnakecase" => cs(ScreamingSnake),
-            "snake" | "snakecase" => cs(Snake),
-            "lower" | "lowercase" => cs(Lower),
-            "upper" | "uppercase" => cs(Upper),
-            "verbatim" | "verbatimcase" => cs(Verbatim),
-            s => abort!(name, "unsupported casing: `{}`", s),
-        }
-    }
-}
-
-impl Name {
-    pub fn translate(self, style: CasingStyle) -> TokenStream {
-        use CasingStyle::*;
-
-        match self {
-            Name::Assigned(tokens) => tokens,
-            Name::Derived(ident) => {
-                let s = ident.unraw().to_string();
-                let s = match style {
-                    Pascal => s.to_camel_case(),
-                    Kebab => s.to_kebab_case(),
-                    Camel => s.to_mixed_case(),
-                    ScreamingSnake => s.to_shouty_snake_case(),
-                    Snake => s.to_snake_case(),
-                    Lower => s.to_snake_case().replace("_", ""),
-                    Upper => s.to_shouty_snake_case().replace("_", ""),
-                    Verbatim => s,
-                };
-                quote_spanned!(ident.span()=> #s)
-            }
-        }
-    }
-
-    pub fn translate_char(self, style: CasingStyle) -> TokenStream {
-        use CasingStyle::*;
-
-        match self {
-            Name::Assigned(tokens) => quote!( (#tokens).chars().next().unwrap() ),
-            Name::Derived(ident) => {
-                let s = ident.unraw().to_string();
-                let s = match style {
-                    Pascal => s.to_camel_case(),
-                    Kebab => s.to_kebab_case(),
-                    Camel => s.to_mixed_case(),
-                    ScreamingSnake => s.to_shouty_snake_case(),
-                    Snake => s.to_snake_case(),
-                    Lower => s.to_snake_case(),
-                    Upper => s.to_shouty_snake_case(),
-                    Verbatim => s,
-                };
-
-                let s = s.chars().next().unwrap();
-                quote_spanned!(ident.span()=> #s)
-            }
-        }
-    }
-}
-
 impl Attrs {
-    fn new(
-        default_span: Span,
-        name: Name,
-        ty: Option<Type>,
-        casing: Sp<CasingStyle>,
-        env_casing: Sp<CasingStyle>,
-    ) -> Self {
-        Self {
-            name,
-            ty,
-            casing,
-            env_casing,
-            doc_comment: vec![],
-            methods: vec![],
-            parser: Parser::default_spanned(default_span),
-            author: None,
-            version: None,
-            verbatim_doc_comment: None,
-            help_heading: None,
-            is_enum: false,
-            has_custom_parser: false,
-            kind: Sp::new(Kind::Arg(Sp::new(Ty::Other, default_span)), default_span),
-        }
-    }
-
-    fn push_method(&mut self, name: Ident, arg: impl ToTokens) {
-        if name == "name" {
-            self.name = Name::Assigned(quote!(#arg));
-        } else if name == "version" {
-            self.version = Some(Method::new(name, quote!(#arg)));
-        } else {
-            self.methods.push(Method::new(name, quote!(#arg)))
-        }
-    }
-
-    fn push_attrs(&mut self, attrs: &[Attribute]) {
-        use ClapAttr::*;
-
-        for attr in parse_clap_attributes(attrs) {
-            match attr {
-                Short(ident) => {
-                    self.push_method(ident, self.name.clone().translate_char(*self.casing));
-                }
-
-                Long(ident) => {
-                    self.push_method(ident, self.name.clone().translate(*self.casing));
-                }
-
-                Env(ident) => {
-                    self.push_method(ident, self.name.clone().translate(*self.env_casing));
-                }
-
-                ArgEnum(_) => self.is_enum = true,
-
-                FromGlobal(ident) => {
-                    let ty = Sp::call_site(Ty::Other);
-                    let kind = Sp::new(Kind::FromGlobal(ty), ident.span());
-                    self.set_kind(kind);
-                }
-
-                Subcommand(ident) => {
-                    let ty = Sp::call_site(Ty::Other);
-                    let kind = Sp::new(Kind::Subcommand(ty), ident.span());
-                    self.set_kind(kind);
-                }
-
-                ExternalSubcommand(ident) => {
-                    let kind = Sp::new(Kind::ExternalSubcommand, ident.span());
-                    self.set_kind(kind);
-                }
-
-                Flatten(ident) => {
-                    let kind = Sp::new(Kind::Flatten, ident.span());
-                    self.set_kind(kind);
-                }
-
-                Skip(ident, expr) => {
-                    let kind = Sp::new(Kind::Skip(expr), ident.span());
-                    self.set_kind(kind);
-                }
-
-                VerbatimDocComment(ident) => self.verbatim_doc_comment = Some(ident),
-
-                DefaultValueT(ident, expr) => {
-                    let ty = if let Some(ty) = self.ty.as_ref() {
-                        ty
-                    } else {
-                        abort!(
-                            ident,
-                            "#[clap(default_value_t)] (without an argument) can be used \
-                            only on field level";
-
-                            note = "see \
-                                https://docs.rs/structopt/0.3.5/structopt/#magical-methods")
-                    };
-
-                    let val = if let Some(expr) = expr {
-                        quote!(#expr)
-                    } else {
-                        quote!(<#ty as ::std::default::Default>::default())
-                    };
-
-                    let val = quote_spanned!(ident.span()=> {
-                        clap::lazy_static::lazy_static! {
-                            static ref DEFAULT_VALUE: &'static str = {
-                                let val: #ty = #val;
-                                let s = ::std::string::ToString::to_string(&val);
-                                ::std::boxed::Box::leak(s.into_boxed_str())
-                            };
-                        }
-                        *DEFAULT_VALUE
-                    });
-
-                    let raw_ident = Ident::new("default_value", ident.span());
-                    self.methods.push(Method::new(raw_ident, val));
-                }
-
-                HelpHeading(ident, expr) => {
-                    self.help_heading = Some(Method::new(ident, quote!(#expr)));
-                }
-
-                About(ident, about) => {
-                    let method = Method::from_lit_or_env(ident, about, "CARGO_PKG_DESCRIPTION");
-                    self.methods.push(method);
-                }
-
-                Author(ident, author) => {
-                    self.author = Some(Method::from_lit_or_env(ident, author, "CARGO_PKG_AUTHORS"));
-                }
-
-                Version(ident, version) => {
-                    self.version =
-                        Some(Method::from_lit_or_env(ident, version, "CARGO_PKG_VERSION"));
-                }
-
-                NameLitStr(name, lit) => {
-                    self.push_method(name, lit);
-                }
-
-                NameExpr(name, expr) => {
-                    self.push_method(name, expr);
-                }
-
-                MethodCall(name, args) => self.push_method(name, quote!(#(#args),*)),
-
-                RenameAll(_, casing_lit) => {
-                    self.casing = CasingStyle::from_lit(casing_lit);
-                }
-
-                RenameAllEnv(_, casing_lit) => {
-                    self.env_casing = CasingStyle::from_lit(casing_lit);
-                }
-
-                Parse(ident, spec) => {
-                    self.has_custom_parser = true;
-                    self.parser = Parser::from_spec(ident, spec);
-                }
-            }
-        }
-    }
-
-    fn push_doc_comment(&mut self, attrs: &[Attribute], name: &str) {
-        use syn::Lit::*;
-        use syn::Meta::*;
-
-        let comment_parts: Vec<_> = attrs
-            .iter()
-            .filter(|attr| attr.path.is_ident("doc"))
-            .filter_map(|attr| {
-                if let Ok(NameValue(MetaNameValue { lit: Str(s), .. })) = attr.parse_meta() {
-                    Some(s.value())
-                } else {
-                    // non #[doc = "..."] attributes are not our concern
-                    // we leave them for rustc to handle
-                    None
-                }
-            })
-            .collect();
-
-        self.doc_comment =
-            process_doc_comment(comment_parts, name, self.verbatim_doc_comment.is_none());
-    }
-
     pub fn from_struct(
         span: Span,
         attrs: &[Attribute],
@@ -759,6 +361,189 @@ impl Attrs {
         res
     }
 
+    fn new(
+        default_span: Span,
+        name: Name,
+        ty: Option<Type>,
+        casing: Sp<CasingStyle>,
+        env_casing: Sp<CasingStyle>,
+    ) -> Self {
+        Self {
+            name,
+            ty,
+            casing,
+            env_casing,
+            doc_comment: vec![],
+            methods: vec![],
+            parser: Parser::default_spanned(default_span),
+            author: None,
+            version: None,
+            verbatim_doc_comment: None,
+            help_heading: None,
+            is_enum: false,
+            has_custom_parser: false,
+            kind: Sp::new(Kind::Arg(Sp::new(Ty::Other, default_span)), default_span),
+        }
+    }
+
+    fn push_method(&mut self, name: Ident, arg: impl ToTokens) {
+        if name == "name" {
+            self.name = Name::Assigned(quote!(#arg));
+        } else if name == "version" {
+            self.version = Some(Method::new(name, quote!(#arg)));
+        } else {
+            self.methods.push(Method::new(name, quote!(#arg)))
+        }
+    }
+
+    fn push_attrs(&mut self, attrs: &[Attribute]) {
+        use ClapAttr::*;
+
+        for attr in parse_clap_attributes(attrs) {
+            match attr {
+                Short(ident) => {
+                    self.push_method(ident, self.name.clone().translate_char(*self.casing));
+                }
+
+                Long(ident) => {
+                    self.push_method(ident, self.name.clone().translate(*self.casing));
+                }
+
+                Env(ident) => {
+                    self.push_method(ident, self.name.clone().translate(*self.env_casing));
+                }
+
+                ArgEnum(_) => self.is_enum = true,
+
+                FromGlobal(ident) => {
+                    let ty = Sp::call_site(Ty::Other);
+                    let kind = Sp::new(Kind::FromGlobal(ty), ident.span());
+                    self.set_kind(kind);
+                }
+
+                Subcommand(ident) => {
+                    let ty = Sp::call_site(Ty::Other);
+                    let kind = Sp::new(Kind::Subcommand(ty), ident.span());
+                    self.set_kind(kind);
+                }
+
+                ExternalSubcommand(ident) => {
+                    let kind = Sp::new(Kind::ExternalSubcommand, ident.span());
+                    self.set_kind(kind);
+                }
+
+                Flatten(ident) => {
+                    let kind = Sp::new(Kind::Flatten, ident.span());
+                    self.set_kind(kind);
+                }
+
+                Skip(ident, expr) => {
+                    let kind = Sp::new(Kind::Skip(expr), ident.span());
+                    self.set_kind(kind);
+                }
+
+                VerbatimDocComment(ident) => self.verbatim_doc_comment = Some(ident),
+
+                DefaultValueT(ident, expr) => {
+                    let ty = if let Some(ty) = self.ty.as_ref() {
+                        ty
+                    } else {
+                        abort!(
+                            ident,
+                            "#[clap(default_value_t)] (without an argument) can be used \
+                            only on field level";
+
+                            note = "see \
+                                https://docs.rs/structopt/0.3.5/structopt/#magical-methods")
+                    };
+
+                    let val = if let Some(expr) = expr {
+                        quote!(#expr)
+                    } else {
+                        quote!(<#ty as ::std::default::Default>::default())
+                    };
+
+                    let val = quote_spanned!(ident.span()=> {
+                        clap::lazy_static::lazy_static! {
+                            static ref DEFAULT_VALUE: &'static str = {
+                                let val: #ty = #val;
+                                let s = ::std::string::ToString::to_string(&val);
+                                ::std::boxed::Box::leak(s.into_boxed_str())
+                            };
+                        }
+                        *DEFAULT_VALUE
+                    });
+
+                    let raw_ident = Ident::new("default_value", ident.span());
+                    self.methods.push(Method::new(raw_ident, val));
+                }
+
+                HelpHeading(ident, expr) => {
+                    self.help_heading = Some(Method::new(ident, quote!(#expr)));
+                }
+
+                About(ident, about) => {
+                    let method = Method::from_lit_or_env(ident, about, "CARGO_PKG_DESCRIPTION");
+                    self.methods.push(method);
+                }
+
+                Author(ident, author) => {
+                    self.author = Some(Method::from_lit_or_env(ident, author, "CARGO_PKG_AUTHORS"));
+                }
+
+                Version(ident, version) => {
+                    self.version =
+                        Some(Method::from_lit_or_env(ident, version, "CARGO_PKG_VERSION"));
+                }
+
+                NameLitStr(name, lit) => {
+                    self.push_method(name, lit);
+                }
+
+                NameExpr(name, expr) => {
+                    self.push_method(name, expr);
+                }
+
+                MethodCall(name, args) => self.push_method(name, quote!(#(#args),*)),
+
+                RenameAll(_, casing_lit) => {
+                    self.casing = CasingStyle::from_lit(casing_lit);
+                }
+
+                RenameAllEnv(_, casing_lit) => {
+                    self.env_casing = CasingStyle::from_lit(casing_lit);
+                }
+
+                Parse(ident, spec) => {
+                    self.has_custom_parser = true;
+                    self.parser = Parser::from_spec(ident, spec);
+                }
+            }
+        }
+    }
+
+    fn push_doc_comment(&mut self, attrs: &[Attribute], name: &str) {
+        use syn::Lit::*;
+        use syn::Meta::*;
+
+        let comment_parts: Vec<_> = attrs
+            .iter()
+            .filter(|attr| attr.path.is_ident("doc"))
+            .filter_map(|attr| {
+                if let Ok(NameValue(MetaNameValue { lit: Str(s), .. })) = attr.parse_meta() {
+                    Some(s.value())
+                } else {
+                    // non #[doc = "..."] attributes are not our concern
+                    // we leave them for rustc to handle
+                    None
+                }
+            })
+            .collect();
+
+        self.doc_comment =
+            process_doc_comment(comment_parts, name, self.verbatim_doc_comment.is_none());
+    }
+
     fn set_kind(&mut self, kind: Sp<Kind>) {
         if let Kind::Arg(_) = *self.kind {
             self.kind = kind;
@@ -868,6 +653,63 @@ impl Attrs {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
+pub enum Kind {
+    Arg(Sp<Ty>),
+    FromGlobal(Sp<Ty>),
+    Subcommand(Sp<Ty>),
+    Flatten,
+    Skip(Option<Expr>),
+    ExternalSubcommand,
+}
+
+#[derive(Clone)]
+pub struct Method {
+    name: Ident,
+    args: TokenStream,
+}
+
+impl Method {
+    pub fn new(name: Ident, args: TokenStream) -> Self {
+        Method { name, args }
+    }
+
+    fn from_lit_or_env(ident: Ident, lit: Option<LitStr>, env_var: &str) -> Self {
+        let mut lit = match lit {
+            Some(lit) => lit,
+
+            None => match env::var(env_var) {
+                Ok(val) => LitStr::new(&val, ident.span()),
+                Err(_) => {
+                    abort!(ident,
+                        "cannot derive `{}` from Cargo.toml", ident;
+                        note = "`{}` environment variable is not set", env_var;
+                        help = "use `{} = \"...\"` to set {} manually", ident, ident;
+                    );
+                }
+            },
+        };
+
+        if ident == "author" {
+            let edited = process_author_str(&lit.value());
+            lit = LitStr::new(&edited, lit.span());
+        }
+
+        Method::new(ident, quote!(#lit))
+    }
+}
+
+impl ToTokens for Method {
+    fn to_tokens(&self, ts: &mut proc_macro2::TokenStream) {
+        let Method { ref name, ref args } = self;
+
+        let tokens = quote!( .#name(#args) );
+
+        tokens.to_tokens(ts);
+    }
+}
+
 /// replace all `:` with `, ` when not inside the `<>`
 ///
 /// `"author1:author2:author3" => "author1, author2, author3"`
@@ -891,4 +733,162 @@ fn process_author_str(author: &str) -> String {
     }
 
     res
+}
+
+#[derive(Clone)]
+pub struct Parser {
+    pub kind: Sp<ParserKind>,
+    pub func: TokenStream,
+}
+
+impl Parser {
+    fn default_spanned(span: Span) -> Sp<Self> {
+        let kind = Sp::new(ParserKind::TryFromStr, span);
+        let func = quote_spanned!(span=> ::std::str::FromStr::from_str);
+        Sp::new(Parser { kind, func }, span)
+    }
+
+    fn from_spec(parse_ident: Ident, spec: ParserSpec) -> Sp<Self> {
+        use self::ParserKind::*;
+
+        let kind = match &*spec.kind.to_string() {
+            "from_str" => FromStr,
+            "try_from_str" => TryFromStr,
+            "from_os_str" => FromOsStr,
+            "try_from_os_str" => TryFromOsStr,
+            "from_occurrences" => FromOccurrences,
+            "from_flag" => FromFlag,
+            s => abort!(spec.kind.span(), "unsupported parser `{}`", s),
+        };
+
+        let func = match spec.parse_func {
+            None => match kind {
+                FromStr | FromOsStr => {
+                    quote_spanned!(spec.kind.span()=> ::std::convert::From::from)
+                }
+                TryFromStr => quote_spanned!(spec.kind.span()=> ::std::str::FromStr::from_str),
+                TryFromOsStr => abort!(
+                    spec.kind.span(),
+                    "you must set parser for `try_from_os_str` explicitly"
+                ),
+                FromOccurrences => quote_spanned!(spec.kind.span()=> { |v| v as _ }),
+                FromFlag => quote_spanned!(spec.kind.span()=> ::std::convert::From::from),
+            },
+
+            Some(func) => match func {
+                Expr::Path(_) => quote!(#func),
+                _ => abort!(func, "`parse` argument must be a function path"),
+            },
+        };
+
+        let kind = Sp::new(kind, spec.kind.span());
+        let parser = Parser { kind, func };
+        Sp::new(parser, parse_ident.span())
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ParserKind {
+    FromStr,
+    TryFromStr,
+    FromOsStr,
+    TryFromOsStr,
+    FromOccurrences,
+    FromFlag,
+}
+
+/// Defines the casing for the attributes long representation.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum CasingStyle {
+    /// Indicate word boundaries with uppercase letter, excluding the first word.
+    Camel,
+    /// Keep all letters lowercase and indicate word boundaries with hyphens.
+    Kebab,
+    /// Indicate word boundaries with uppercase letter, including the first word.
+    Pascal,
+    /// Keep all letters uppercase and indicate word boundaries with underscores.
+    ScreamingSnake,
+    /// Keep all letters lowercase and indicate word boundaries with underscores.
+    Snake,
+    /// Keep all letters lowercase and remove word boundaries.
+    Lower,
+    /// Keep all letters uppercase and remove word boundaries.
+    Upper,
+    /// Use the original attribute name defined in the code.
+    Verbatim,
+}
+
+impl CasingStyle {
+    fn from_lit(name: LitStr) -> Sp<Self> {
+        use self::CasingStyle::*;
+
+        let normalized = name.value().to_camel_case().to_lowercase();
+        let cs = |kind| Sp::new(kind, name.span());
+
+        match normalized.as_ref() {
+            "camel" | "camelcase" => cs(Camel),
+            "kebab" | "kebabcase" => cs(Kebab),
+            "pascal" | "pascalcase" => cs(Pascal),
+            "screamingsnake" | "screamingsnakecase" => cs(ScreamingSnake),
+            "snake" | "snakecase" => cs(Snake),
+            "lower" | "lowercase" => cs(Lower),
+            "upper" | "uppercase" => cs(Upper),
+            "verbatim" | "verbatimcase" => cs(Verbatim),
+            s => abort!(name, "unsupported casing: `{}`", s),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum Name {
+    Derived(Ident),
+    Assigned(TokenStream),
+}
+
+impl Name {
+    pub fn translate(self, style: CasingStyle) -> TokenStream {
+        use CasingStyle::*;
+
+        match self {
+            Name::Assigned(tokens) => tokens,
+            Name::Derived(ident) => {
+                let s = ident.unraw().to_string();
+                let s = match style {
+                    Pascal => s.to_camel_case(),
+                    Kebab => s.to_kebab_case(),
+                    Camel => s.to_mixed_case(),
+                    ScreamingSnake => s.to_shouty_snake_case(),
+                    Snake => s.to_snake_case(),
+                    Lower => s.to_snake_case().replace("_", ""),
+                    Upper => s.to_shouty_snake_case().replace("_", ""),
+                    Verbatim => s,
+                };
+                quote_spanned!(ident.span()=> #s)
+            }
+        }
+    }
+
+    pub fn translate_char(self, style: CasingStyle) -> TokenStream {
+        use CasingStyle::*;
+
+        match self {
+            Name::Assigned(tokens) => quote!( (#tokens).chars().next().unwrap() ),
+            Name::Derived(ident) => {
+                let s = ident.unraw().to_string();
+                let s = match style {
+                    Pascal => s.to_camel_case(),
+                    Kebab => s.to_kebab_case(),
+                    Camel => s.to_mixed_case(),
+                    ScreamingSnake => s.to_shouty_snake_case(),
+                    Snake => s.to_snake_case(),
+                    Lower => s.to_snake_case(),
+                    Upper => s.to_shouty_snake_case(),
+                    Verbatim => s,
+                };
+
+                let s = s.chars().next().unwrap();
+                quote_spanned!(ident.span()=> #s)
+            }
+        }
+    }
 }

--- a/clap_derive/src/parse.rs
+++ b/clap_derive/src/parse.rs
@@ -9,6 +9,17 @@ use syn::{
     Attribute, Expr, ExprLit, Ident, Lit, LitBool, LitStr, Token,
 };
 
+pub fn parse_clap_attributes(all_attrs: &[Attribute]) -> Vec<ClapAttr> {
+    all_attrs
+        .iter()
+        .filter(|attr| attr.path.is_ident("clap") || attr.path.is_ident("structopt"))
+        .flat_map(|attr| {
+            attr.parse_args_with(Punctuated::<ClapAttr, Token![,]>::parse_terminated)
+                .unwrap_or_abort()
+        })
+        .collect()
+}
+
 #[allow(clippy::large_enum_variant)]
 pub enum ClapAttr {
     // single-identifier attributes
@@ -269,15 +280,4 @@ fn raw_method_suggestion(ts: ParseBuffer) -> String {
          https://docs.rs/structopt/0.3/structopt/#raw-methods"
             .into()
     }
-}
-
-pub fn parse_clap_attributes(all_attrs: &[Attribute]) -> Vec<ClapAttr> {
-    all_attrs
-        .iter()
-        .filter(|attr| attr.path.is_ident("clap") || attr.path.is_ident("structopt"))
-        .flat_map(|attr| {
-            attr.parse_args_with(Punctuated::<ClapAttr, Token![,]>::parse_terminated)
-                .unwrap_or_abort()
-        })
-        .collect()
 }

--- a/src/build/app/debug_asserts.rs
+++ b/src/build/app/debug_asserts.rs
@@ -5,43 +5,6 @@ use crate::{
 };
 use std::cmp::Ordering;
 
-#[derive(Eq)]
-enum Flag<'a> {
-    App(String, &'a str),
-    Arg(String, &'a str),
-}
-
-impl PartialEq for Flag<'_> {
-    fn eq(&self, other: &Flag) -> bool {
-        self.cmp(other) == Ordering::Equal
-    }
-}
-
-impl PartialOrd for Flag<'_> {
-    fn partial_cmp(&self, other: &Flag) -> Option<Ordering> {
-        use Flag::*;
-
-        match (self, other) {
-            (App(s1, _), App(s2, _))
-            | (Arg(s1, _), Arg(s2, _))
-            | (App(s1, _), Arg(s2, _))
-            | (Arg(s1, _), App(s2, _)) => {
-                if s1 == s2 {
-                    Some(Ordering::Equal)
-                } else {
-                    s1.partial_cmp(s2)
-                }
-            }
-        }
-    }
-}
-
-impl Ord for Flag<'_> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
-    }
-}
-
 pub(crate) fn assert_app(app: &App) {
     debug!("App::_debug_asserts");
 
@@ -299,6 +262,43 @@ pub(crate) fn assert_app(app: &App) {
 
     app._panic_on_missing_help(app.g_settings.is_set(AppSettings::HelpExpected));
     assert_app_flags(app);
+}
+
+#[derive(Eq)]
+enum Flag<'a> {
+    App(String, &'a str),
+    Arg(String, &'a str),
+}
+
+impl PartialEq for Flag<'_> {
+    fn eq(&self, other: &Flag) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl PartialOrd for Flag<'_> {
+    fn partial_cmp(&self, other: &Flag) -> Option<Ordering> {
+        use Flag::*;
+
+        match (self, other) {
+            (App(s1, _), App(s2, _))
+            | (Arg(s1, _), Arg(s2, _))
+            | (App(s1, _), Arg(s2, _))
+            | (Arg(s1, _), App(s2, _)) => {
+                if s1 == s2 {
+                    Some(Ordering::Equal)
+                } else {
+                    s1.partial_cmp(s2)
+                }
+            }
+        }
+    }
+}
+
+impl Ord for Flag<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
 }
 
 fn detect_duplicate_flags(flags: &[Flag], short_or_long: &str) {

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -4,57 +4,6 @@ use std::{ops::BitOr, str::FromStr};
 // Third party
 use bitflags::bitflags;
 
-bitflags! {
-    struct Flags: u64 {
-        const SC_NEGATE_REQS                 = 1;
-        const SC_REQUIRED                    = 1 << 1;
-        const ARG_REQUIRED_ELSE_HELP         = 1 << 2;
-        const PROPAGATE_VERSION              = 1 << 3;
-        const DISABLE_VERSION_FOR_SC         = 1 << 4;
-        const WAIT_ON_ERROR                  = 1 << 6;
-        const SC_REQUIRED_ELSE_HELP          = 1 << 7;
-        const NO_AUTO_HELP                   = 1 << 8;
-        const NO_AUTO_VERSION                = 1 << 9;
-        const DISABLE_VERSION_FLAG           = 1 << 10;
-        const HIDDEN                         = 1 << 11;
-        const TRAILING_VARARG                = 1 << 12;
-        const NO_BIN_NAME                    = 1 << 13;
-        const ALLOW_UNK_SC                   = 1 << 14;
-        const SC_UTF8_NONE                   = 1 << 15;
-        const LEADING_HYPHEN                 = 1 << 16;
-        const NO_POS_VALUES                  = 1 << 17;
-        const NEXT_LINE_HELP                 = 1 << 18;
-        const DERIVE_DISP_ORDER              = 1 << 19;
-        const DISABLE_COLORED_HELP           = 1 << 20;
-        const COLOR_ALWAYS                   = 1 << 21;
-        const COLOR_AUTO                     = 1 << 22;
-        const COLOR_NEVER                    = 1 << 23;
-        const DONT_DELIM_TRAIL               = 1 << 24;
-        const ALLOW_NEG_NUMS                 = 1 << 25;
-        const DISABLE_HELP_SC                = 1 << 27;
-        const DONT_COLLAPSE_ARGS             = 1 << 28;
-        const ARGS_NEGATE_SCS                = 1 << 29;
-        const PROPAGATE_VALS_DOWN            = 1 << 30;
-        const ALLOW_MISSING_POS              = 1 << 31;
-        const TRAILING_VALUES                = 1 << 32;
-        const BUILT                          = 1 << 33;
-        const BIN_NAME_BUILT                 = 1 << 34;
-        const VALID_ARG_FOUND                = 1 << 35;
-        const INFER_SUBCOMMANDS              = 1 << 36;
-        const CONTAINS_LAST                  = 1 << 37;
-        const ARGS_OVERRIDE_SELF             = 1 << 38;
-        const HELP_REQUIRED                  = 1 << 39;
-        const SUBCOMMAND_PRECEDENCE_OVER_ARG = 1 << 40;
-        const DISABLE_HELP_FLAG              = 1 << 41;
-        const USE_LONG_FORMAT_FOR_HELP_SC    = 1 << 42;
-        const INFER_LONG_ARGS                = 1 << 43;
-        const IGNORE_ERRORS                  = 1 << 44;
-        #[cfg(feature = "unstable-multicall")]
-        const MULTICALL                      = 1 << 45;
-        const NO_OP                          = 0;
-    }
-}
-
 #[doc(hidden)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct AppFlags(Flags);
@@ -65,103 +14,6 @@ impl Default for AppFlags {
     }
 }
 
-impl_settings! { AppSettings, AppFlags,
-    ArgRequiredElseHelp("argrequiredelsehelp")
-        => Flags::ARG_REQUIRED_ELSE_HELP,
-    SubcommandPrecedenceOverArg("subcommandprecedenceoverarg")
-        => Flags::SUBCOMMAND_PRECEDENCE_OVER_ARG,
-    ArgsNegateSubcommands("argsnegatesubcommands")
-        => Flags::ARGS_NEGATE_SCS,
-    AllowExternalSubcommands("allowexternalsubcommands")
-        => Flags::ALLOW_UNK_SC,
-    StrictUtf8("strictutf8")
-        => Flags::NO_OP,
-    AllowInvalidUtf8ForExternalSubcommands("allowinvalidutf8forexternalsubcommands")
-        => Flags::SC_UTF8_NONE,
-    AllowHyphenValues("allowhyphenvalues")
-        => Flags::LEADING_HYPHEN,
-    AllowLeadingHyphen("allowleadinghyphen")
-        => Flags::LEADING_HYPHEN,
-    AllowNegativeNumbers("allownegativenumbers")
-        => Flags::ALLOW_NEG_NUMS,
-    AllowMissingPositional("allowmissingpositional")
-        => Flags::ALLOW_MISSING_POS,
-    ColoredHelp("coloredhelp")
-        => Flags::NO_OP,
-    ColorAlways("coloralways")
-        => Flags::COLOR_ALWAYS,
-    ColorAuto("colorauto")
-        => Flags::COLOR_AUTO,
-    ColorNever("colornever")
-        => Flags::COLOR_NEVER,
-    DontDelimitTrailingValues("dontdelimittrailingvalues")
-        => Flags::DONT_DELIM_TRAIL,
-    DontCollapseArgsInUsage("dontcollapseargsinusage")
-        => Flags::DONT_COLLAPSE_ARGS,
-    DeriveDisplayOrder("derivedisplayorder")
-        => Flags::DERIVE_DISP_ORDER,
-    DisableColoredHelp("disablecoloredhelp")
-        => Flags::DISABLE_COLORED_HELP,
-    DisableHelpSubcommand("disablehelpsubcommand")
-        => Flags::DISABLE_HELP_SC,
-    DisableHelpFlag("disablehelpflag")
-        => Flags::DISABLE_HELP_FLAG,
-    DisableHelpFlags("disablehelpflags")
-        => Flags::DISABLE_HELP_FLAG,
-    DisableVersionFlag("disableversionflag")
-        => Flags::DISABLE_VERSION_FLAG,
-    DisableVersion("disableversion")
-        => Flags::DISABLE_VERSION_FLAG,
-    PropagateVersion("propagateversion")
-        => Flags::PROPAGATE_VERSION,
-    GlobalVersion("propagateversion")
-        => Flags::PROPAGATE_VERSION,
-    HidePossibleValues("hidepossiblevalues")
-        => Flags::NO_POS_VALUES,
-    HidePossibleValuesInHelp("hidepossiblevaluesinhelp")
-        => Flags::NO_POS_VALUES,
-    HelpExpected("helpexpected")
-        => Flags::HELP_REQUIRED,
-    Hidden("hidden")
-        => Flags::HIDDEN,
-    #[cfg(feature = "unstable-multicall")]
-    Multicall("multicall")
-        => Flags::MULTICALL,
-    NoAutoHelp("noautohelp")
-        => Flags::NO_AUTO_HELP,
-    NoAutoVersion("noautoversion")
-        => Flags::NO_AUTO_VERSION,
-    NoBinaryName("nobinaryname")
-        => Flags::NO_BIN_NAME,
-    SubcommandsNegateReqs("subcommandsnegatereqs")
-        => Flags::SC_NEGATE_REQS,
-    SubcommandRequired("subcommandrequired")
-        => Flags::SC_REQUIRED,
-    SubcommandRequiredElseHelp("subcommandrequiredelsehelp")
-        => Flags::SC_REQUIRED_ELSE_HELP,
-    UseLongFormatForHelpSubcommand("uselongformatforhelpsubcommand")
-        => Flags::USE_LONG_FORMAT_FOR_HELP_SC,
-    TrailingVarArg("trailingvararg")
-        => Flags::TRAILING_VARARG,
-    UnifiedHelp("unifiedhelp") => Flags::NO_OP,
-    NextLineHelp("nextlinehelp")
-        => Flags::NEXT_LINE_HELP,
-    IgnoreErrors("ignoreerrors")
-        => Flags::IGNORE_ERRORS,
-    WaitOnError("waitonerror")
-        => Flags::WAIT_ON_ERROR,
-    Built("built")
-        => Flags::BUILT,
-    BinNameBuilt("binnamebuilt")
-        => Flags::BIN_NAME_BUILT,
-    InferSubcommands("infersubcommands")
-        => Flags::INFER_SUBCOMMANDS,
-    AllArgsOverrideSelf("allargsoverrideself")
-        => Flags::ARGS_OVERRIDE_SELF,
-    InferLongArgs("inferlongargs")
-        => Flags::INFER_LONG_ARGS
-}
-
 /// Application level settings, which affect how [`App`] operates
 ///
 /// **NOTE:** When these settings are used, they apply only to current command, and are *not*
@@ -170,54 +22,44 @@ impl_settings! { AppSettings, AppFlags,
 /// [`App`]: crate::App
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum AppSettings {
-    /// Deprecated, this is now the default, see [`AppSettings::AllowInvalidUtf8ForExternalSubcommands`] and [`ArgSettings::AllowInvalidUtf8`][crate::ArgSettings::AllowInvalidUtf8] for the opposite.
-    #[deprecated(
-        since = "3.0.0",
-        note = "This is now the default see `AppSettings::AllowInvalidUtf8ForExternalSubcommands` and `ArgSettings::AllowInvalidUtf8` for the opposite."
-    )]
-    StrictUtf8,
+    /// Try not to fail on parse errors, like missing option values.
+    ///
+    /// **Note:** Make sure you apply it as `global_setting` if you want this setting
+    /// to be propagated to subcommands and sub-subcommands!
+    ///
+    /// ```rust
+    /// # use clap::{App, arg, AppSettings};
+    /// let app = App::new("app")
+    ///   .global_setting(AppSettings::IgnoreErrors)
+    ///   .arg(arg!(-c --config <FILE> "Sets a custom config file").required(false))
+    ///   .arg(arg!(-x --stuff <FILE> "Sets a custom stuff file").required(false))
+    ///   .arg(arg!(f: -f "Flag"));
+    ///
+    /// let r = app.try_get_matches_from(vec!["app", "-c", "file", "-f", "-x"]);
+    ///
+    /// assert!(r.is_ok(), "unexpected error: {:?}", r);
+    /// let m = r.unwrap();
+    /// assert_eq!(m.value_of("config"), Some("file"));
+    /// assert!(m.is_present("f"));
+    /// assert_eq!(m.value_of("stuff"), None);
+    /// ```
+    IgnoreErrors,
 
-    /// Specifies that external subcommands that are invalid UTF-8 should *not* be treated as an error.
+    /// Display the message "Press \[ENTER\]/\[RETURN\] to continue..." and wait for user before
+    /// exiting
     ///
-    /// **NOTE:** Using external subcommand argument values with invalid UTF-8 requires using
-    /// [`ArgMatches::values_of_os`] or [`ArgMatches::values_of_lossy`] for those particular
-    /// arguments which may contain invalid UTF-8 values
-    ///
-    /// **NOTE:** Setting this requires [`AppSettings::AllowExternalSubcommands`]
-    ///
-    /// # Platform Specific
-    ///
-    /// Non Windows systems only
+    /// This is most useful when writing an application which is run from a GUI shortcut, or on
+    /// Windows where a user tries to open the binary by double-clicking instead of using the
+    /// command line.
     ///
     /// # Examples
     ///
-    #[cfg_attr(not(unix), doc = " ```ignore")]
-    #[cfg_attr(unix, doc = " ```")]
-    /// # use clap::{App, AppSettings};
-    /// // Assume there is an external subcommand named "subcmd"
-    /// let m = App::new("myprog")
-    ///     .setting(AppSettings::AllowInvalidUtf8ForExternalSubcommands)
-    ///     .setting(AppSettings::AllowExternalSubcommands)
-    ///     .get_matches_from(vec![
-    ///         "myprog", "subcmd", "--option", "value", "-fff", "--flag"
-    ///     ]);
-    ///
-    /// // All trailing arguments will be stored under the subcommand's sub-matches using an empty
-    /// // string argument name
-    /// match m.subcommand() {
-    ///     Some((external, ext_m)) => {
-    ///          let ext_args: Vec<&std::ffi::OsStr> = ext_m.values_of_os("").unwrap().collect();
-    ///          assert_eq!(external, "subcmd");
-    ///          assert_eq!(ext_args, ["--option", "value", "-fff", "--flag"]);
-    ///     },
-    ///     _ => {},
-    /// }
+    /// ```rust
+    /// # use clap::{App, Arg, AppSettings};
+    /// App::new("myprog")
+    ///     .global_setting(AppSettings::WaitOnError);
     /// ```
-    ///
-    /// [`ArgMatches::values_of_os`]: crate::ArgMatches::values_of_os()
-    /// [`ArgMatches::values_of_lossy`]: crate::ArgMatches::values_of_lossy()
-    /// [`subcommands`]: crate::App::subcommand()
-    AllowInvalidUtf8ForExternalSubcommands,
+    WaitOnError,
 
     /// Specifies that leading hyphens are allowed in all argument *values* (e.g. `-10`).
     ///
@@ -246,21 +88,6 @@ pub enum AppSettings {
     /// [`Arg::allow_hyphen_values`]: crate::Arg::allow_hyphen_values()
     AllowHyphenValues,
 
-    /// Deprecated, replaced with [`AppSettings::AllowHyphenValues`]
-    #[deprecated(
-        since = "3.0.0",
-        note = "Replaced with `AppSettings::AllowHyphenValues`"
-    )]
-    AllowLeadingHyphen,
-
-    /// Specifies that all arguments override themselves.
-    ///
-    /// This is the equivalent to saying the `foo` arg using [`Arg::overrides_with("foo")`] for all
-    /// defined arguments.
-    ///
-    /// [`Arg::overrides_with("foo")`]: crate::Arg::overrides_with()
-    AllArgsOverrideSelf,
-
     /// Allows negative numbers to pass as values.
     ///
     /// This is similar to [`AppSettings::AllowHyphenValues`] except that it only allows numbers,
@@ -281,6 +108,14 @@ pub enum AppSettings {
     /// assert_eq!(m.value_of("num").unwrap(), "-20");
     /// ```
     AllowNegativeNumbers,
+
+    /// Specifies that all arguments override themselves.
+    ///
+    /// This is the equivalent to saying the `foo` arg using [`Arg::overrides_with("foo")`] for all
+    /// defined arguments.
+    ///
+    /// [`Arg::overrides_with("foo")`]: crate::Arg::overrides_with()
+    AllArgsOverrideSelf,
 
     /// Allows one to implement two styles of CLIs where positionals can be used out of order.
     ///
@@ -391,6 +226,133 @@ pub enum AppSettings {
     /// [required]: crate::Arg::required()
     AllowMissingPositional,
 
+    /// Specifies that the final positional argument is a "VarArg" and that `clap` should not
+    /// attempt to parse any further args.
+    ///
+    /// The values of the trailing positional argument will contain all args from itself on.
+    ///
+    /// **NOTE:** The final positional argument **must** have [`Arg::multiple_values(true)`] or the usage
+    /// string equivalent.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, arg, AppSettings};
+    /// let m = App::new("myprog")
+    ///     .setting(AppSettings::TrailingVarArg)
+    ///     .arg(arg!(<cmd> ... "commands to run"))
+    ///     .get_matches_from(vec!["myprog", "arg1", "-r", "val1"]);
+    ///
+    /// let trail: Vec<&str> = m.values_of("cmd").unwrap().collect();
+    /// assert_eq!(trail, ["arg1", "-r", "val1"]);
+    /// ```
+    /// [`Arg::multiple_values(true)`]: crate::Arg::multiple_values()
+    TrailingVarArg,
+
+    /// Disables the automatic delimiting of values when `--` or [`AppSettings::TrailingVarArg`]
+    /// was used.
+    ///
+    /// **NOTE:** The same thing can be done manually by setting the final positional argument to
+    /// [`Arg::use_delimiter(false)`]. Using this setting is safer, because it's easier to locate
+    /// when making changes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, AppSettings};
+    /// App::new("myprog")
+    ///     .setting(AppSettings::DontDelimitTrailingValues)
+    ///     .get_matches();
+    /// ```
+    ///
+    /// [`Arg::use_delimiter(false)`]: crate::Arg::use_delimiter()
+    DontDelimitTrailingValues,
+
+    /// Allow partial matches of long arguments or their [aliases].
+    ///
+    /// For example, to match an argument named `--test`, one could use `--t`, `--te`, `--tes`, and
+    /// `--test`.
+    ///
+    /// **NOTE:** The match *must not* be ambiguous at all in order to succeed. i.e. to match
+    /// `--te` to `--test` there could not also be another argument or alias `--temp` because both
+    /// start with `--te`
+    ///
+    /// [aliases]: crate::App::aliases()
+    InferLongArgs,
+
+    /// Allow partial matches of [subcommand] names and their [aliases].
+    ///
+    /// For example, to match a subcommand named `test`, one could use `t`, `te`, `tes`, and
+    /// `test`.
+    ///
+    /// **NOTE:** The match *must not* be ambiguous at all in order to succeed. i.e. to match `te`
+    /// to `test` there could not also be a subcommand or alias `temp` because both start with `te`
+    ///
+    /// **CAUTION:** This setting can interfere with [positional/free arguments], take care when
+    /// designing CLIs which allow inferred subcommands and have potential positional/free
+    /// arguments whose values could start with the same characters as subcommands. If this is the
+    /// case, it's recommended to use settings such as [`AppSettings::ArgsNegateSubcommands`] in
+    /// conjunction with this setting.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, AppSettings};
+    /// let m = App::new("prog")
+    ///     .global_setting(AppSettings::InferSubcommands)
+    ///     .subcommand(App::new("test"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "te"
+    ///     ]);
+    /// assert_eq!(m.subcommand_name(), Some("test"));
+    /// ```
+    ///
+    /// [subcommand]: crate::App::subcommand()
+    /// [positional/free arguments]: crate::Arg::index()
+    /// [aliases]: crate::App::aliases()
+    InferSubcommands,
+
+    /// If no [`subcommand`] is present at runtime, error and exit gracefully.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, AppSettings, ErrorKind};
+    /// let err = App::new("myprog")
+    ///     .setting(AppSettings::SubcommandRequired)
+    ///     .subcommand(App::new("test"))
+    ///     .try_get_matches_from(vec![
+    ///         "myprog",
+    ///     ]);
+    /// assert!(err.is_err());
+    /// assert_eq!(err.unwrap_err().kind, ErrorKind::MissingSubcommand);
+    /// # ;
+    /// ```
+    ///
+    /// [`subcommand`]: crate::App::subcommand()
+    SubcommandRequired,
+
+    /// Display help if no [`subcommands`] are present at runtime and exit gracefully (i.e. an
+    /// empty run such as `$ myprog`).
+    ///
+    /// **NOTE:** This should *not* be used with [`AppSettings::SubcommandRequired`] as they do
+    /// nearly same thing; this prints the help text, and the other prints an error.
+    ///
+    /// **NOTE:** If the user specifies arguments at runtime, but no subcommand the help text will
+    /// still be displayed and exit. If this is *not* the desired result, consider using
+    /// [`AppSettings::ArgRequiredElseHelp`] instead.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, AppSettings};
+    /// App::new("myprog")
+    ///     .setting(AppSettings::SubcommandRequiredElseHelp);
+    /// ```
+    ///
+    /// [`subcommands`]: crate::App::subcommand()
+    SubcommandRequiredElseHelp,
+
     /// Assume unexpected positional arguments are a [`subcommand`].
     ///
     /// **NOTE:** Use this setting with caution,
@@ -425,249 +387,6 @@ pub enum AppSettings {
     /// [`ArgMatches`]: crate::ArgMatches
     /// [`ErrorKind::UnknownArgument`]: crate::ErrorKind::UnknownArgument
     AllowExternalSubcommands,
-
-    /// Specifies that use of an argument prevents the use of [`subcommands`].
-    ///
-    /// By default `clap` allows arguments between subcommands such
-    /// as `<cmd> [cmd_args] <subcmd> [subcmd_args] <subsubcmd> [subsubcmd_args]`.
-    ///
-    /// This setting disables that functionality and says that arguments can
-    /// only follow the *final* subcommand. For instance using this setting
-    /// makes only the following invocations possible:
-    ///
-    /// * `<cmd> <subcmd> <subsubcmd> [subsubcmd_args]`
-    /// * `<cmd> <subcmd> [subcmd_args]`
-    /// * `<cmd> [cmd_args]`
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, AppSettings};
-    /// App::new("myprog")
-    ///     .setting(AppSettings::ArgsNegateSubcommands);
-    /// ```
-    ///
-    /// [`subcommands`]: crate::App::subcommand()
-    ArgsNegateSubcommands,
-
-    /// Exit gracefully if no arguments are present (e.g. `$ myprog`).
-    ///
-    /// **NOTE:** [`subcommands`] count as arguments
-    ///
-    /// **NOTE:** Setting [`Arg::default_value`] effectively disables this option as it will
-    /// ensure that some argument is always present.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, AppSettings};
-    /// App::new("myprog")
-    ///     .setting(AppSettings::ArgRequiredElseHelp);
-    /// ```
-    ///
-    /// [`subcommands`]: crate::App::subcommand()
-    /// [`Arg::default_value`]: crate::Arg::default_value()
-    ArgRequiredElseHelp,
-
-    /// Prevent subcommands from being consumed as an arguments value.
-    ///
-    /// By default, if an option taking multiple values is followed by a subcommand, the
-    /// subcommand will be parsed as another value.
-    ///
-    /// ```text
-    /// app --foo val1 val2 subcommand
-    ///           --------- ----------
-    ///             values   another value
-    /// ```
-    ///
-    /// This setting instructs the parser to stop when encountering a subcommand instead of
-    /// greedily consuming arguments.
-    ///
-    /// ```text
-    /// app --foo val1 val2 subcommand
-    ///           --------- ----------
-    ///             values   subcommand
-    /// ```
-    ///
-    /// **Note:** Make sure you apply it as `global_setting` if you want this setting
-    /// to be propagated to subcommands and sub-subcommands!
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, AppSettings, Arg};
-    /// let app = App::new("app").subcommand(App::new("sub")).arg(
-    ///     Arg::new("arg")
-    ///         .long("arg")
-    ///         .multiple_values(true)
-    ///         .takes_value(true),
-    /// );
-    ///
-    /// let matches = app
-    ///     .clone()
-    ///     .try_get_matches_from(&["app", "--arg", "1", "2", "3", "sub"])
-    ///     .unwrap();
-    ///
-    /// assert_eq!(
-    ///     matches.values_of("arg").unwrap().collect::<Vec<_>>(),
-    ///     &["1", "2", "3", "sub"]
-    /// );
-    /// assert!(matches.subcommand_matches("sub").is_none());
-    ///
-    /// let matches = app
-    ///     .setting(AppSettings::SubcommandPrecedenceOverArg)
-    ///     .try_get_matches_from(&["app", "--arg", "1", "2", "3", "sub"])
-    ///     .unwrap();
-    ///
-    /// assert_eq!(
-    ///     matches.values_of("arg").unwrap().collect::<Vec<_>>(),
-    ///     &["1", "2", "3"]
-    /// );
-    /// assert!(matches.subcommand_matches("sub").is_some());
-    /// ```
-    SubcommandPrecedenceOverArg,
-
-    /// Deprecated, this is now the default
-    #[deprecated(since = "3.0.0", note = "This is now the default")]
-    ColoredHelp,
-
-    /// Deprecated, see [`App::color`][crate::App::color]
-    #[deprecated(since = "3.0.0", note = "Replaced with `App::color`")]
-    ColorAuto,
-
-    /// Deprecated, replaced with [`App::color`][crate::App::color]
-    #[deprecated(since = "3.0.0", note = "Replaced with `App::color`")]
-    ColorAlways,
-
-    /// Deprecated, replaced with [`App::color`][crate::App::color]
-    #[deprecated(since = "3.0.0", note = "Replaced with `App::color`")]
-    ColorNever,
-
-    /// Disables the automatic collapsing of positional args into `[ARGS]` inside the usage string.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{App, Arg, AppSettings};
-    /// App::new("myprog")
-    ///     .global_setting(AppSettings::DontCollapseArgsInUsage)
-    ///     .get_matches();
-    /// ```
-    DontCollapseArgsInUsage,
-
-    /// Disables the automatic delimiting of values when `--` or [`AppSettings::TrailingVarArg`]
-    /// was used.
-    ///
-    /// **NOTE:** The same thing can be done manually by setting the final positional argument to
-    /// [`Arg::use_delimiter(false)`]. Using this setting is safer, because it's easier to locate
-    /// when making changes.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{App, Arg, AppSettings};
-    /// App::new("myprog")
-    ///     .setting(AppSettings::DontDelimitTrailingValues)
-    ///     .get_matches();
-    /// ```
-    ///
-    /// [`Arg::use_delimiter(false)`]: crate::Arg::use_delimiter()
-    DontDelimitTrailingValues,
-
-    /// Disables colorized help messages.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{App, AppSettings};
-    /// App::new("myprog")
-    ///     .setting(AppSettings::DisableColoredHelp)
-    ///     .get_matches();
-    /// ```
-    DisableColoredHelp,
-
-    /// Disables `-h` and `--help` flag.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, AppSettings, ErrorKind};
-    /// let res = App::new("myprog")
-    ///     .setting(AppSettings::DisableHelpFlag)
-    ///     .try_get_matches_from(vec![
-    ///         "myprog", "-h"
-    ///     ]);
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
-    /// ```
-    DisableHelpFlag,
-
-    /// Deprecated, replaced with [`AppSettings::DisableHelpFlag`]
-    #[deprecated(since = "3.0.0", note = "Replaced with `AppSettings::DisableHelpFlag`")]
-    DisableHelpFlags,
-
-    /// Disables the `help` [`subcommand`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, AppSettings, ErrorKind, };
-    /// let res = App::new("myprog")
-    ///     .setting(AppSettings::DisableHelpSubcommand)
-    ///     // Normally, creating a subcommand causes a `help` subcommand to automatically
-    ///     // be generated as well
-    ///     .subcommand(App::new("test"))
-    ///     .try_get_matches_from(vec![
-    ///         "myprog", "help"
-    ///     ]);
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
-    /// ```
-    ///
-    /// [`subcommand`]: crate::App::subcommand()
-    DisableHelpSubcommand,
-
-    /// Disables `-V` and `--version` flag.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, AppSettings, ErrorKind};
-    /// let res = App::new("myprog")
-    ///     .setting(AppSettings::DisableVersionFlag)
-    ///     .try_get_matches_from(vec![
-    ///         "myprog", "-V"
-    ///     ]);
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
-    /// ```
-    DisableVersionFlag,
-
-    /// Deprecated, replaced with [`AppSettings::DisableVersionFlag`]
-    #[deprecated(
-        since = "3.0.0",
-        note = "Replaced with `AppSettings::DisableVersionFlag`"
-    )]
-    DisableVersion,
-
-    /// Displays the arguments and [`subcommands`] in the help message in the order that they were
-    /// declared in, and not alphabetically which is the default.
-    ///
-    /// To override the declaration order, see [`Arg::display_order`] and [`App::display_order`].
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{App, Arg, AppSettings};
-    /// App::new("myprog")
-    ///     .global_setting(AppSettings::DeriveDisplayOrder)
-    ///     .get_matches();
-    /// ```
-    ///
-    /// [`subcommands`]: crate::App::subcommand()
-    /// [`Arg::display_order`]: crate::Arg::display_order
-    /// [`App::display_order`]: crate::App::display_order
-    DeriveDisplayOrder,
 
     /// Parse the bin name (`argv[0]`) as a subcommand
     ///
@@ -752,194 +471,69 @@ pub enum AppSettings {
     #[cfg(feature = "unstable-multicall")]
     Multicall,
 
-    /// Specifies to use the version of the current command for all [`subcommands`].
+    /// Specifies that external subcommands that are invalid UTF-8 should *not* be treated as an error.
     ///
-    /// Defaults to `false`; subcommands have independent version strings from their parents.
+    /// **NOTE:** Using external subcommand argument values with invalid UTF-8 requires using
+    /// [`ArgMatches::values_of_os`] or [`ArgMatches::values_of_lossy`] for those particular
+    /// arguments which may contain invalid UTF-8 values
     ///
-    /// **Note:** Make sure you apply it as `global_setting` if you want this setting
-    /// to be propagated to subcommands and sub-subcommands!
+    /// **NOTE:** Setting this requires [`AppSettings::AllowExternalSubcommands`]
     ///
-    /// # Examples
+    /// # Platform Specific
     ///
-    /// ```no_run
-    /// # use clap::{App, Arg, AppSettings};
-    /// App::new("myprog")
-    ///     .version("v1.1")
-    ///     .global_setting(AppSettings::PropagateVersion)
-    ///     .subcommand(App::new("test"))
-    ///     .get_matches();
-    /// // running `$ myprog test --version` will display
-    /// // "myprog-test v1.1"
-    /// ```
-    ///
-    /// [`subcommands`]: crate::App::subcommand()
-    PropagateVersion,
-
-    /// Deprecated, replaced with [`AppSettings::PropagateVersion`]
-    #[deprecated(
-        since = "3.0.0",
-        note = "Replaced with `AppSettings::PropagateVersion`"
-    )]
-    GlobalVersion,
-
-    /// Specifies that this [`subcommand`] should be hidden from help messages
+    /// Non Windows systems only
     ///
     /// # Examples
     ///
-    /// ```rust
-    /// # use clap::{App, Arg, AppSettings, };
-    /// App::new("myprog")
-    ///     .subcommand(App::new("test")
-    ///     .setting(AppSettings::Hidden))
-    /// # ;
-    /// ```
-    ///
-    /// [`subcommand`]: crate::App::subcommand()
-    Hidden,
-
-    /// Tells `clap` *not* to print possible values when displaying help information.
-    ///
-    /// This can be useful if there are many values, or they are explained elsewhere.
-    ///
-    /// To set this per argument, see
-    /// [`Arg::hide_possible_values`][crate::Arg::hide_possible_values].
-    HidePossibleValues,
-    /// Deprecated, replaced with [`AppSettings::HidePossibleValues`]
-    #[deprecated(
-        since = "3.0.0",
-        note = "Replaced with AppSettings::HidePossibleValues"
-    )]
-    HidePossibleValuesInHelp,
-
-    /// Panic if help descriptions are omitted.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, AppSettings};
-    /// App::new("myprog")
-    ///     .global_setting(AppSettings::HelpExpected)
-    ///     .arg(
-    ///         Arg::new("foo").help("It does foo stuff")
-    ///         // As required via AppSettings::HelpExpected, a help message was supplied
-    ///      )
-    /// #    .get_matches();
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// ```rust,no_run
-    /// # use clap::{App, Arg, AppSettings};
-    /// App::new("myapp")
-    ///     .global_setting(AppSettings::HelpExpected)
-    ///     .arg(
-    ///         Arg::new("foo")
-    ///         // Someone forgot to put .about("...") here
-    ///         // Since the setting AppSettings::HelpExpected is activated, this will lead to
-    ///         // a panic (if you are in debug mode)
-    ///     )
-    /// #   .get_matches();
-    ///```
-    HelpExpected,
-
-    /// Try not to fail on parse errors, like missing option values.
-    ///
-    /// **Note:** Make sure you apply it as `global_setting` if you want this setting
-    /// to be propagated to subcommands and sub-subcommands!
-    ///
-    /// ```rust
-    /// # use clap::{App, arg, AppSettings};
-    /// let app = App::new("app")
-    ///   .global_setting(AppSettings::IgnoreErrors)
-    ///   .arg(arg!(-c --config <FILE> "Sets a custom config file").required(false))
-    ///   .arg(arg!(-x --stuff <FILE> "Sets a custom stuff file").required(false))
-    ///   .arg(arg!(f: -f "Flag"));
-    ///
-    /// let r = app.try_get_matches_from(vec!["app", "-c", "file", "-f", "-x"]);
-    ///
-    /// assert!(r.is_ok(), "unexpected error: {:?}", r);
-    /// let m = r.unwrap();
-    /// assert_eq!(m.value_of("config"), Some("file"));
-    /// assert!(m.is_present("f"));
-    /// assert_eq!(m.value_of("stuff"), None);
-    /// ```
-    IgnoreErrors,
-
-    /// Allow partial matches of [subcommand] names and their [aliases].
-    ///
-    /// For example, to match a subcommand named `test`, one could use `t`, `te`, `tes`, and
-    /// `test`.
-    ///
-    /// **NOTE:** The match *must not* be ambiguous at all in order to succeed. i.e. to match `te`
-    /// to `test` there could not also be a subcommand or alias `temp` because both start with `te`
-    ///
-    /// **CAUTION:** This setting can interfere with [positional/free arguments], take care when
-    /// designing CLIs which allow inferred subcommands and have potential positional/free
-    /// arguments whose values could start with the same characters as subcommands. If this is the
-    /// case, it's recommended to use settings such as [`AppSettings::ArgsNegateSubcommands`] in
-    /// conjunction with this setting.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{App, Arg, AppSettings};
-    /// let m = App::new("prog")
-    ///     .global_setting(AppSettings::InferSubcommands)
-    ///     .subcommand(App::new("test"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "te"
-    ///     ]);
-    /// assert_eq!(m.subcommand_name(), Some("test"));
-    /// ```
-    ///
-    /// [subcommand]: crate::App::subcommand()
-    /// [positional/free arguments]: crate::Arg::index()
-    /// [aliases]: crate::App::aliases()
-    InferSubcommands,
-
-    /// Allow partial matches of long arguments or their [aliases].
-    ///
-    /// For example, to match an argument named `--test`, one could use `--t`, `--te`, `--tes`, and
-    /// `--test`.
-    ///
-    /// **NOTE:** The match *must not* be ambiguous at all in order to succeed. i.e. to match
-    /// `--te` to `--test` there could not also be another argument or alias `--temp` because both
-    /// start with `--te`
-    ///
-    /// [aliases]: crate::App::aliases()
-    InferLongArgs,
-
-    /// Specifies that the parser should not assume the first argument passed is the binary name.
-    ///
-    /// This is normally the case when using a "daemon" style mode, or an interactive CLI where
-    /// one would not normally type the binary or program name for each command.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, arg, AppSettings};
+    #[cfg_attr(not(unix), doc = " ```ignore")]
+    #[cfg_attr(unix, doc = " ```")]
+    /// # use clap::{App, AppSettings};
+    /// // Assume there is an external subcommand named "subcmd"
     /// let m = App::new("myprog")
-    ///     .setting(AppSettings::NoBinaryName)
-    ///     .arg(arg!(<cmd> ... "commands to run"))
-    ///     .get_matches_from(vec!["command", "set"]);
+    ///     .setting(AppSettings::AllowInvalidUtf8ForExternalSubcommands)
+    ///     .setting(AppSettings::AllowExternalSubcommands)
+    ///     .get_matches_from(vec![
+    ///         "myprog", "subcmd", "--option", "value", "-fff", "--flag"
+    ///     ]);
     ///
-    /// let cmds: Vec<&str> = m.values_of("cmd").unwrap().collect();
-    /// assert_eq!(cmds, ["command", "set"]);
+    /// // All trailing arguments will be stored under the subcommand's sub-matches using an empty
+    /// // string argument name
+    /// match m.subcommand() {
+    ///     Some((external, ext_m)) => {
+    ///          let ext_args: Vec<&std::ffi::OsStr> = ext_m.values_of_os("").unwrap().collect();
+    ///          assert_eq!(external, "subcmd");
+    ///          assert_eq!(ext_args, ["--option", "value", "-fff", "--flag"]);
+    ///     },
+    ///     _ => {},
+    /// }
     /// ```
-    /// [`try_get_matches_from_mut`]: crate::App::try_get_matches_from_mut()
-    NoBinaryName,
+    ///
+    /// [`ArgMatches::values_of_os`]: crate::ArgMatches::values_of_os()
+    /// [`ArgMatches::values_of_lossy`]: crate::ArgMatches::values_of_lossy()
+    /// [`subcommands`]: crate::App::subcommand()
+    AllowInvalidUtf8ForExternalSubcommands,
 
-    /// Places the help string for all arguments on the line after the argument.
+    /// Specifies that the help subcommand should print the long help message (`--help`).
+    ///
+    /// **NOTE:** This setting is useless if [`AppSettings::DisableHelpSubcommand`] or [`AppSettings::NoAutoHelp`] is set,
+    /// or if the app contains no subcommands at all.
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```rust
     /// # use clap::{App, Arg, AppSettings};
     /// App::new("myprog")
-    ///     .global_setting(AppSettings::NextLineHelp)
+    ///     .global_setting(AppSettings::UseLongFormatForHelpSubcommand)
+    ///     .subcommand(App::new("test")
+    ///         .arg(Arg::new("foo")
+    ///             .help("short form about message")
+    ///             .long_help("long form about message")
+    ///         )
+    ///     )
     ///     .get_matches();
     /// ```
-    NextLineHelp,
+    /// [long format]: crate::App::long_about
+    UseLongFormatForHelpSubcommand,
 
     /// Allows [`subcommands`] to override all requirements of the parent command.
     ///
@@ -988,111 +582,311 @@ pub enum AppSettings {
     /// [`subcommands`]: crate::App::subcommand()
     SubcommandsNegateReqs,
 
-    /// Display help if no [`subcommands`] are present at runtime and exit gracefully (i.e. an
-    /// empty run such as `$ myprog`).
+    /// Specifies that use of an argument prevents the use of [`subcommands`].
     ///
-    /// **NOTE:** This should *not* be used with [`AppSettings::SubcommandRequired`] as they do
-    /// nearly same thing; this prints the help text, and the other prints an error.
+    /// By default `clap` allows arguments between subcommands such
+    /// as `<cmd> [cmd_args] <subcmd> [subcmd_args] <subsubcmd> [subsubcmd_args]`.
     ///
-    /// **NOTE:** If the user specifies arguments at runtime, but no subcommand the help text will
-    /// still be displayed and exit. If this is *not* the desired result, consider using
-    /// [`AppSettings::ArgRequiredElseHelp`] instead.
+    /// This setting disables that functionality and says that arguments can
+    /// only follow the *final* subcommand. For instance using this setting
+    /// makes only the following invocations possible:
+    ///
+    /// * `<cmd> <subcmd> <subsubcmd> [subsubcmd_args]`
+    /// * `<cmd> <subcmd> [subcmd_args]`
+    /// * `<cmd> [cmd_args]`
     ///
     /// # Examples
     ///
     /// ```rust
-    /// # use clap::{App, Arg, AppSettings};
+    /// # use clap::{App, AppSettings};
     /// App::new("myprog")
-    ///     .setting(AppSettings::SubcommandRequiredElseHelp);
+    ///     .setting(AppSettings::ArgsNegateSubcommands);
     /// ```
     ///
     /// [`subcommands`]: crate::App::subcommand()
-    SubcommandRequiredElseHelp,
+    ArgsNegateSubcommands,
 
-    /// Specifies that the help subcommand should print the long help message (`--help`).
+    /// Prevent subcommands from being consumed as an arguments value.
     ///
-    /// **NOTE:** This setting is useless if [`AppSettings::DisableHelpSubcommand`] or [`AppSettings::NoAutoHelp`] is set,
-    /// or if the app contains no subcommands at all.
+    /// By default, if an option taking multiple values is followed by a subcommand, the
+    /// subcommand will be parsed as another value.
+    ///
+    /// ```text
+    /// app --foo val1 val2 subcommand
+    ///           --------- ----------
+    ///             values   another value
+    /// ```
+    ///
+    /// This setting instructs the parser to stop when encountering a subcommand instead of
+    /// greedily consuming arguments.
+    ///
+    /// ```text
+    /// app --foo val1 val2 subcommand
+    ///           --------- ----------
+    ///             values   subcommand
+    /// ```
+    ///
+    /// **Note:** Make sure you apply it as `global_setting` if you want this setting
+    /// to be propagated to subcommands and sub-subcommands!
     ///
     /// # Examples
     ///
     /// ```rust
+    /// # use clap::{App, AppSettings, Arg};
+    /// let app = App::new("app").subcommand(App::new("sub")).arg(
+    ///     Arg::new("arg")
+    ///         .long("arg")
+    ///         .multiple_values(true)
+    ///         .takes_value(true),
+    /// );
+    ///
+    /// let matches = app
+    ///     .clone()
+    ///     .try_get_matches_from(&["app", "--arg", "1", "2", "3", "sub"])
+    ///     .unwrap();
+    ///
+    /// assert_eq!(
+    ///     matches.values_of("arg").unwrap().collect::<Vec<_>>(),
+    ///     &["1", "2", "3", "sub"]
+    /// );
+    /// assert!(matches.subcommand_matches("sub").is_none());
+    ///
+    /// let matches = app
+    ///     .setting(AppSettings::SubcommandPrecedenceOverArg)
+    ///     .try_get_matches_from(&["app", "--arg", "1", "2", "3", "sub"])
+    ///     .unwrap();
+    ///
+    /// assert_eq!(
+    ///     matches.values_of("arg").unwrap().collect::<Vec<_>>(),
+    ///     &["1", "2", "3"]
+    /// );
+    /// assert!(matches.subcommand_matches("sub").is_some());
+    /// ```
+    SubcommandPrecedenceOverArg,
+
+    /// Exit gracefully if no arguments are present (e.g. `$ myprog`).
+    ///
+    /// **NOTE:** [`subcommands`] count as arguments
+    ///
+    /// **NOTE:** Setting [`Arg::default_value`] effectively disables this option as it will
+    /// ensure that some argument is always present.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, AppSettings};
+    /// App::new("myprog")
+    ///     .setting(AppSettings::ArgRequiredElseHelp);
+    /// ```
+    ///
+    /// [`subcommands`]: crate::App::subcommand()
+    /// [`Arg::default_value`]: crate::Arg::default_value()
+    ArgRequiredElseHelp,
+
+    /// Displays the arguments and [`subcommands`] in the help message in the order that they were
+    /// declared in, and not alphabetically which is the default.
+    ///
+    /// To override the declaration order, see [`Arg::display_order`] and [`App::display_order`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
     /// # use clap::{App, Arg, AppSettings};
     /// App::new("myprog")
-    ///     .global_setting(AppSettings::UseLongFormatForHelpSubcommand)
-    ///     .subcommand(App::new("test")
-    ///         .arg(Arg::new("foo")
-    ///             .help("short form about message")
-    ///             .long_help("long form about message")
-    ///         )
-    ///     )
+    ///     .global_setting(AppSettings::DeriveDisplayOrder)
     ///     .get_matches();
     /// ```
-    /// [long format]: crate::App::long_about
-    UseLongFormatForHelpSubcommand,
+    ///
+    /// [`subcommands`]: crate::App::subcommand()
+    /// [`Arg::display_order`]: crate::Arg::display_order
+    /// [`App::display_order`]: crate::App::display_order
+    DeriveDisplayOrder,
 
-    /// If no [`subcommand`] is present at runtime, error and exit gracefully.
+    /// Disables the automatic collapsing of positional args into `[ARGS]` inside the usage string.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, AppSettings};
+    /// App::new("myprog")
+    ///     .global_setting(AppSettings::DontCollapseArgsInUsage)
+    ///     .get_matches();
+    /// ```
+    DontCollapseArgsInUsage,
+
+    /// Places the help string for all arguments on the line after the argument.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, AppSettings};
+    /// App::new("myprog")
+    ///     .global_setting(AppSettings::NextLineHelp)
+    ///     .get_matches();
+    /// ```
+    NextLineHelp,
+
+    /// Disables colorized help messages.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, AppSettings};
+    /// App::new("myprog")
+    ///     .setting(AppSettings::DisableColoredHelp)
+    ///     .get_matches();
+    /// ```
+    DisableColoredHelp,
+
+    /// Disables `-h` and `--help` flag.
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use clap::{App, AppSettings, ErrorKind};
-    /// let err = App::new("myprog")
-    ///     .setting(AppSettings::SubcommandRequired)
+    /// let res = App::new("myprog")
+    ///     .setting(AppSettings::DisableHelpFlag)
+    ///     .try_get_matches_from(vec![
+    ///         "myprog", "-h"
+    ///     ]);
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// ```
+    DisableHelpFlag,
+
+    /// Disables the `help` [`subcommand`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, AppSettings, ErrorKind, };
+    /// let res = App::new("myprog")
+    ///     .setting(AppSettings::DisableHelpSubcommand)
+    ///     // Normally, creating a subcommand causes a `help` subcommand to automatically
+    ///     // be generated as well
     ///     .subcommand(App::new("test"))
     ///     .try_get_matches_from(vec![
-    ///         "myprog",
+    ///         "myprog", "help"
     ///     ]);
-    /// assert!(err.is_err());
-    /// assert_eq!(err.unwrap_err().kind, ErrorKind::MissingSubcommand);
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// ```
+    ///
+    /// [`subcommand`]: crate::App::subcommand()
+    DisableHelpSubcommand,
+
+    /// Disables `-V` and `--version` flag.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, AppSettings, ErrorKind};
+    /// let res = App::new("myprog")
+    ///     .setting(AppSettings::DisableVersionFlag)
+    ///     .try_get_matches_from(vec![
+    ///         "myprog", "-V"
+    ///     ]);
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// ```
+    DisableVersionFlag,
+
+    /// Specifies to use the version of the current command for all [`subcommands`].
+    ///
+    /// Defaults to `false`; subcommands have independent version strings from their parents.
+    ///
+    /// **Note:** Make sure you apply it as `global_setting` if you want this setting
+    /// to be propagated to subcommands and sub-subcommands!
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, AppSettings};
+    /// App::new("myprog")
+    ///     .version("v1.1")
+    ///     .global_setting(AppSettings::PropagateVersion)
+    ///     .subcommand(App::new("test"))
+    ///     .get_matches();
+    /// // running `$ myprog test --version` will display
+    /// // "myprog-test v1.1"
+    /// ```
+    ///
+    /// [`subcommands`]: crate::App::subcommand()
+    PropagateVersion,
+
+    /// Specifies that this [`subcommand`] should be hidden from help messages
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, AppSettings, };
+    /// App::new("myprog")
+    ///     .subcommand(App::new("test")
+    ///     .setting(AppSettings::Hidden))
     /// # ;
     /// ```
     ///
     /// [`subcommand`]: crate::App::subcommand()
-    SubcommandRequired,
+    Hidden,
 
-    /// Specifies that the final positional argument is a "VarArg" and that `clap` should not
-    /// attempt to parse any further args.
+    /// Tells `clap` *not* to print possible values when displaying help information.
     ///
-    /// The values of the trailing positional argument will contain all args from itself on.
+    /// This can be useful if there are many values, or they are explained elsewhere.
     ///
-    /// **NOTE:** The final positional argument **must** have [`Arg::multiple_values(true)`] or the usage
-    /// string equivalent.
+    /// To set this per argument, see
+    /// [`Arg::hide_possible_values`][crate::Arg::hide_possible_values].
+    HidePossibleValues,
+
+    /// Panic if help descriptions are omitted.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, AppSettings};
+    /// App::new("myprog")
+    ///     .global_setting(AppSettings::HelpExpected)
+    ///     .arg(
+    ///         Arg::new("foo").help("It does foo stuff")
+    ///         // As required via AppSettings::HelpExpected, a help message was supplied
+    ///      )
+    /// #    .get_matches();
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// ```rust,no_run
+    /// # use clap::{App, Arg, AppSettings};
+    /// App::new("myapp")
+    ///     .global_setting(AppSettings::HelpExpected)
+    ///     .arg(
+    ///         Arg::new("foo")
+    ///         // Someone forgot to put .about("...") here
+    ///         // Since the setting AppSettings::HelpExpected is activated, this will lead to
+    ///         // a panic (if you are in debug mode)
+    ///     )
+    /// #   .get_matches();
+    ///```
+    HelpExpected,
+
+    /// Specifies that the parser should not assume the first argument passed is the binary name.
+    ///
+    /// This is normally the case when using a "daemon" style mode, or an interactive CLI where
+    /// one would not normally type the binary or program name for each command.
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use clap::{App, arg, AppSettings};
     /// let m = App::new("myprog")
-    ///     .setting(AppSettings::TrailingVarArg)
+    ///     .setting(AppSettings::NoBinaryName)
     ///     .arg(arg!(<cmd> ... "commands to run"))
-    ///     .get_matches_from(vec!["myprog", "arg1", "-r", "val1"]);
+    ///     .get_matches_from(vec!["command", "set"]);
     ///
-    /// let trail: Vec<&str> = m.values_of("cmd").unwrap().collect();
-    /// assert_eq!(trail, ["arg1", "-r", "val1"]);
+    /// let cmds: Vec<&str> = m.values_of("cmd").unwrap().collect();
+    /// assert_eq!(cmds, ["command", "set"]);
     /// ```
-    /// [`Arg::multiple_values(true)`]: crate::Arg::multiple_values()
-    TrailingVarArg,
-
-    /// Deprecated, this is now the default
-    #[deprecated(since = "3.0.0", note = "This is now the default")]
-    UnifiedHelp,
-
-    /// Display the message "Press \[ENTER\]/\[RETURN\] to continue..." and wait for user before
-    /// exiting
-    ///
-    /// This is most useful when writing an application which is run from a GUI shortcut, or on
-    /// Windows where a user tries to open the binary by double-clicking instead of using the
-    /// command line.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, AppSettings};
-    /// App::new("myprog")
-    ///     .global_setting(AppSettings::WaitOnError);
-    /// ```
-    WaitOnError,
+    /// [`try_get_matches_from_mut`]: crate::App::try_get_matches_from_mut()
+    NoBinaryName,
 
     /// Treat the auto-generated `-h, --help` flags like any other flag, and *not* print the help
     /// message.
@@ -1137,6 +931,65 @@ pub enum AppSettings {
     /// ```
     NoAutoVersion,
 
+    /// Deprecated, replaced with [`AppSettings::AllowHyphenValues`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Replaced with `AppSettings::AllowHyphenValues`"
+    )]
+    AllowLeadingHyphen,
+
+    /// Deprecated, this is now the default, see [`AppSettings::AllowInvalidUtf8ForExternalSubcommands`] and [`ArgSettings::AllowInvalidUtf8`][crate::ArgSettings::AllowInvalidUtf8] for the opposite.
+    #[deprecated(
+        since = "3.0.0",
+        note = "This is now the default see `AppSettings::AllowInvalidUtf8ForExternalSubcommands` and `ArgSettings::AllowInvalidUtf8` for the opposite."
+    )]
+    StrictUtf8,
+
+    /// Deprecated, this is now the default
+    #[deprecated(since = "3.0.0", note = "This is now the default")]
+    ColoredHelp,
+
+    /// Deprecated, see [`App::color`][crate::App::color]
+    #[deprecated(since = "3.0.0", note = "Replaced with `App::color`")]
+    ColorAuto,
+
+    /// Deprecated, replaced with [`App::color`][crate::App::color]
+    #[deprecated(since = "3.0.0", note = "Replaced with `App::color`")]
+    ColorAlways,
+
+    /// Deprecated, replaced with [`App::color`][crate::App::color]
+    #[deprecated(since = "3.0.0", note = "Replaced with `App::color`")]
+    ColorNever,
+
+    /// Deprecated, replaced with [`AppSettings::DisableHelpFlag`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `AppSettings::DisableHelpFlag`")]
+    DisableHelpFlags,
+
+    /// Deprecated, replaced with [`AppSettings::DisableVersionFlag`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Replaced with `AppSettings::DisableVersionFlag`"
+    )]
+    DisableVersion,
+
+    /// Deprecated, replaced with [`AppSettings::PropagateVersion`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Replaced with `AppSettings::PropagateVersion`"
+    )]
+    GlobalVersion,
+
+    /// Deprecated, replaced with [`AppSettings::HidePossibleValues`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Replaced with AppSettings::HidePossibleValues"
+    )]
+    HidePossibleValuesInHelp,
+
+    /// Deprecated, this is now the default
+    #[deprecated(since = "3.0.0", note = "This is now the default")]
+    UnifiedHelp,
+
     /// If the app is already built, used for caching.
     #[doc(hidden)]
     Built,
@@ -1144,6 +997,154 @@ pub enum AppSettings {
     /// If the app's bin name is already built, used for caching.
     #[doc(hidden)]
     BinNameBuilt,
+}
+
+bitflags! {
+    struct Flags: u64 {
+        const SC_NEGATE_REQS                 = 1;
+        const SC_REQUIRED                    = 1 << 1;
+        const ARG_REQUIRED_ELSE_HELP         = 1 << 2;
+        const PROPAGATE_VERSION              = 1 << 3;
+        const DISABLE_VERSION_FOR_SC         = 1 << 4;
+        const WAIT_ON_ERROR                  = 1 << 6;
+        const SC_REQUIRED_ELSE_HELP          = 1 << 7;
+        const NO_AUTO_HELP                   = 1 << 8;
+        const NO_AUTO_VERSION                = 1 << 9;
+        const DISABLE_VERSION_FLAG           = 1 << 10;
+        const HIDDEN                         = 1 << 11;
+        const TRAILING_VARARG                = 1 << 12;
+        const NO_BIN_NAME                    = 1 << 13;
+        const ALLOW_UNK_SC                   = 1 << 14;
+        const SC_UTF8_NONE                   = 1 << 15;
+        const LEADING_HYPHEN                 = 1 << 16;
+        const NO_POS_VALUES                  = 1 << 17;
+        const NEXT_LINE_HELP                 = 1 << 18;
+        const DERIVE_DISP_ORDER              = 1 << 19;
+        const DISABLE_COLORED_HELP           = 1 << 20;
+        const COLOR_ALWAYS                   = 1 << 21;
+        const COLOR_AUTO                     = 1 << 22;
+        const COLOR_NEVER                    = 1 << 23;
+        const DONT_DELIM_TRAIL               = 1 << 24;
+        const ALLOW_NEG_NUMS                 = 1 << 25;
+        const DISABLE_HELP_SC                = 1 << 27;
+        const DONT_COLLAPSE_ARGS             = 1 << 28;
+        const ARGS_NEGATE_SCS                = 1 << 29;
+        const PROPAGATE_VALS_DOWN            = 1 << 30;
+        const ALLOW_MISSING_POS              = 1 << 31;
+        const TRAILING_VALUES                = 1 << 32;
+        const BUILT                          = 1 << 33;
+        const BIN_NAME_BUILT                 = 1 << 34;
+        const VALID_ARG_FOUND                = 1 << 35;
+        const INFER_SUBCOMMANDS              = 1 << 36;
+        const CONTAINS_LAST                  = 1 << 37;
+        const ARGS_OVERRIDE_SELF             = 1 << 38;
+        const HELP_REQUIRED                  = 1 << 39;
+        const SUBCOMMAND_PRECEDENCE_OVER_ARG = 1 << 40;
+        const DISABLE_HELP_FLAG              = 1 << 41;
+        const USE_LONG_FORMAT_FOR_HELP_SC    = 1 << 42;
+        const INFER_LONG_ARGS                = 1 << 43;
+        const IGNORE_ERRORS                  = 1 << 44;
+        #[cfg(feature = "unstable-multicall")]
+        const MULTICALL                      = 1 << 45;
+        const NO_OP                          = 0;
+    }
+}
+
+impl_settings! { AppSettings, AppFlags,
+    ArgRequiredElseHelp("argrequiredelsehelp")
+        => Flags::ARG_REQUIRED_ELSE_HELP,
+    SubcommandPrecedenceOverArg("subcommandprecedenceoverarg")
+        => Flags::SUBCOMMAND_PRECEDENCE_OVER_ARG,
+    ArgsNegateSubcommands("argsnegatesubcommands")
+        => Flags::ARGS_NEGATE_SCS,
+    AllowExternalSubcommands("allowexternalsubcommands")
+        => Flags::ALLOW_UNK_SC,
+    StrictUtf8("strictutf8")
+        => Flags::NO_OP,
+    AllowInvalidUtf8ForExternalSubcommands("allowinvalidutf8forexternalsubcommands")
+        => Flags::SC_UTF8_NONE,
+    AllowHyphenValues("allowhyphenvalues")
+        => Flags::LEADING_HYPHEN,
+    AllowLeadingHyphen("allowleadinghyphen")
+        => Flags::LEADING_HYPHEN,
+    AllowNegativeNumbers("allownegativenumbers")
+        => Flags::ALLOW_NEG_NUMS,
+    AllowMissingPositional("allowmissingpositional")
+        => Flags::ALLOW_MISSING_POS,
+    ColoredHelp("coloredhelp")
+        => Flags::NO_OP,
+    ColorAlways("coloralways")
+        => Flags::COLOR_ALWAYS,
+    ColorAuto("colorauto")
+        => Flags::COLOR_AUTO,
+    ColorNever("colornever")
+        => Flags::COLOR_NEVER,
+    DontDelimitTrailingValues("dontdelimittrailingvalues")
+        => Flags::DONT_DELIM_TRAIL,
+    DontCollapseArgsInUsage("dontcollapseargsinusage")
+        => Flags::DONT_COLLAPSE_ARGS,
+    DeriveDisplayOrder("derivedisplayorder")
+        => Flags::DERIVE_DISP_ORDER,
+    DisableColoredHelp("disablecoloredhelp")
+        => Flags::DISABLE_COLORED_HELP,
+    DisableHelpSubcommand("disablehelpsubcommand")
+        => Flags::DISABLE_HELP_SC,
+    DisableHelpFlag("disablehelpflag")
+        => Flags::DISABLE_HELP_FLAG,
+    DisableHelpFlags("disablehelpflags")
+        => Flags::DISABLE_HELP_FLAG,
+    DisableVersionFlag("disableversionflag")
+        => Flags::DISABLE_VERSION_FLAG,
+    DisableVersion("disableversion")
+        => Flags::DISABLE_VERSION_FLAG,
+    PropagateVersion("propagateversion")
+        => Flags::PROPAGATE_VERSION,
+    GlobalVersion("propagateversion")
+        => Flags::PROPAGATE_VERSION,
+    HidePossibleValues("hidepossiblevalues")
+        => Flags::NO_POS_VALUES,
+    HidePossibleValuesInHelp("hidepossiblevaluesinhelp")
+        => Flags::NO_POS_VALUES,
+    HelpExpected("helpexpected")
+        => Flags::HELP_REQUIRED,
+    Hidden("hidden")
+        => Flags::HIDDEN,
+    #[cfg(feature = "unstable-multicall")]
+    Multicall("multicall")
+        => Flags::MULTICALL,
+    NoAutoHelp("noautohelp")
+        => Flags::NO_AUTO_HELP,
+    NoAutoVersion("noautoversion")
+        => Flags::NO_AUTO_VERSION,
+    NoBinaryName("nobinaryname")
+        => Flags::NO_BIN_NAME,
+    SubcommandsNegateReqs("subcommandsnegatereqs")
+        => Flags::SC_NEGATE_REQS,
+    SubcommandRequired("subcommandrequired")
+        => Flags::SC_REQUIRED,
+    SubcommandRequiredElseHelp("subcommandrequiredelsehelp")
+        => Flags::SC_REQUIRED_ELSE_HELP,
+    UseLongFormatForHelpSubcommand("uselongformatforhelpsubcommand")
+        => Flags::USE_LONG_FORMAT_FOR_HELP_SC,
+    TrailingVarArg("trailingvararg")
+        => Flags::TRAILING_VARARG,
+    UnifiedHelp("unifiedhelp") => Flags::NO_OP,
+    NextLineHelp("nextlinehelp")
+        => Flags::NEXT_LINE_HELP,
+    IgnoreErrors("ignoreerrors")
+        => Flags::IGNORE_ERRORS,
+    WaitOnError("waitonerror")
+        => Flags::WAIT_ON_ERROR,
+    Built("built")
+        => Flags::BUILT,
+    BinNameBuilt("binnamebuilt")
+        => Flags::BIN_NAME_BUILT,
+    InferSubcommands("infersubcommands")
+        => Flags::INFER_SUBCOMMANDS,
+    AllArgsOverrideSelf("allargsoverrideself")
+        => Flags::ARGS_OVERRIDE_SELF,
+    InferLongArgs("inferlongargs")
+        => Flags::INFER_LONG_ARGS
 }
 
 #[cfg(test)]

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -39,22 +39,6 @@ mod regex;
 #[cfg(feature = "regex")]
 pub use self::regex::RegexRef;
 
-type Validator<'a> = dyn FnMut(&str) -> Result<(), Box<dyn Error + Send + Sync>> + Send + 'a;
-type ValidatorOs<'a> = dyn FnMut(&OsStr) -> Result<(), Box<dyn Error + Send + Sync>> + Send + 'a;
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) enum ArgProvider {
-    Generated,
-    GeneratedMutated,
-    User,
-}
-
-impl Default for ArgProvider {
-    fn default() -> Self {
-        ArgProvider::User
-    }
-}
-
 /// The abstract representation of a command line argument. Used to set all the options and
 /// relationships that define a valid argument for the program.
 ///
@@ -119,198 +103,6 @@ pub struct Arg<'help> {
     pub(crate) value_hint: ValueHint,
 }
 
-/// Getters
-impl<'help> Arg<'help> {
-    /// Get the name of the argument
-    #[inline]
-    pub fn get_name(&self) -> &'help str {
-        self.name
-    }
-
-    /// Get the help specified for this argument, if any
-    #[inline]
-    pub fn get_help(&self) -> Option<&'help str> {
-        self.help
-    }
-
-    /// Get the long help specified for this argument, if any
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// let arg = Arg::new("foo").long_help("long help");
-    /// assert_eq!(Some("long help"), arg.get_long_help());
-    /// ```
-    ///
-    #[inline]
-    pub fn get_long_help(&self) -> Option<&'help str> {
-        self.long_help
-    }
-
-    /// Get the help heading specified for this argument, if any
-    #[inline]
-    pub fn get_help_heading(&self) -> Option<&'help str> {
-        self.help_heading.unwrap_or_default()
-    }
-
-    /// Get the short option name for this argument, if any
-    #[inline]
-    pub fn get_short(&self) -> Option<char> {
-        self.short
-    }
-
-    /// Get visible short aliases for this argument, if any
-    #[inline]
-    pub fn get_visible_short_aliases(&self) -> Option<Vec<char>> {
-        if self.short_aliases.is_empty() {
-            None
-        } else {
-            Some(
-                self.short_aliases
-                    .iter()
-                    .filter_map(|(c, v)| if *v { Some(c) } else { None })
-                    .copied()
-                    .collect(),
-            )
-        }
-    }
-
-    /// Get the short option name and its visible aliases, if any
-    #[inline]
-    pub fn get_short_and_visible_aliases(&self) -> Option<Vec<char>> {
-        let mut shorts = match self.short {
-            Some(short) => vec![short],
-            None => return None,
-        };
-        if let Some(aliases) = self.get_visible_short_aliases() {
-            shorts.extend(aliases);
-        }
-        Some(shorts)
-    }
-
-    /// Get the long option name for this argument, if any
-    #[inline]
-    pub fn get_long(&self) -> Option<&'help str> {
-        self.long
-    }
-
-    /// Get visible aliases for this argument, if any
-    #[inline]
-    pub fn get_visible_aliases(&self) -> Option<Vec<&'help str>> {
-        if self.aliases.is_empty() {
-            None
-        } else {
-            Some(
-                self.aliases
-                    .iter()
-                    .filter_map(|(s, v)| if *v { Some(s) } else { None })
-                    .copied()
-                    .collect(),
-            )
-        }
-    }
-
-    /// Get the long option name and its visible aliases, if any
-    #[inline]
-    pub fn get_long_and_visible_aliases(&self) -> Option<Vec<&'help str>> {
-        let mut longs = match self.long {
-            Some(long) => vec![long],
-            None => return None,
-        };
-        if let Some(aliases) = self.get_visible_aliases() {
-            longs.extend(aliases);
-        }
-        Some(longs)
-    }
-
-    /// Get the list of the possible values for this argument, if any
-    #[inline]
-    pub fn get_possible_values(&self) -> Option<&[PossibleValue]> {
-        if self.possible_vals.is_empty() {
-            None
-        } else {
-            Some(&self.possible_vals)
-        }
-    }
-
-    /// Get the names of values for this argument.
-    #[inline]
-    pub fn get_value_names(&self) -> Option<&[&'help str]> {
-        if self.val_names.is_empty() {
-            None
-        } else {
-            Some(&self.val_names)
-        }
-    }
-
-    /// Get the number of values for this argument.
-    #[inline]
-    pub fn get_num_vals(&self) -> Option<usize> {
-        self.num_vals
-    }
-
-    /// Get the index of this argument, if any
-    #[inline]
-    pub fn get_index(&self) -> Option<usize> {
-        self.index
-    }
-
-    /// Get the value hint of this argument
-    pub fn get_value_hint(&self) -> ValueHint {
-        self.value_hint
-    }
-
-    /// Get information on if this argument is global or not
-    pub fn get_global(&self) -> bool {
-        self.is_set(ArgSettings::Global)
-    }
-
-    /// Get the environment variable name specified for this argument, if any
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use std::ffi::OsStr;
-    /// # use clap::Arg;
-    /// let arg = Arg::new("foo").env("ENVIRONMENT");
-    /// assert_eq!(Some(OsStr::new("ENVIRONMENT")), arg.get_env());
-    /// ```
-    #[cfg(feature = "env")]
-    pub fn get_env(&self) -> Option<&OsStr> {
-        self.env.as_ref().map(|x| x.0)
-    }
-
-    /// Get the default values specified for this argument, if any
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// let arg = Arg::new("foo").default_value("default value");
-    /// assert_eq!(&["default value"], arg.get_default_values());
-    /// ```
-    pub fn get_default_values(&self) -> &[&OsStr] {
-        &self.default_vals
-    }
-
-    /// Checks whether this argument is a positional or not.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use clap::Arg;
-    /// let arg = Arg::new("foo");
-    /// assert_eq!(true, arg.is_positional());
-    ///
-    /// let arg = Arg::new("foo").long("foo");
-    /// assert_eq!(false, arg.is_positional());
-    /// ```
-    pub fn is_positional(&self) -> bool {
-        self.long.is_none() && self.short.is_none()
-    }
-}
-
 impl<'help> Arg<'help> {
     /// Create a new [`Arg`] with a unique name.
     ///
@@ -336,96 +128,6 @@ impl<'help> Arg<'help> {
             name,
             ..Default::default()
         }
-    }
-
-    /// Deprecated, replaced with [`Arg::new`]
-    #[deprecated(since = "3.0.0", note = "Replaced with `Arg::new`")]
-    pub fn with_name<S: Into<&'help str>>(n: S) -> Self {
-        Self::new(n)
-    }
-
-    /// Deprecated in [Issue #9](https://github.com/epage/clapng/issues/9), maybe [`clap::Parser`][crate::Parser] would fit your use case?
-    #[cfg(feature = "yaml")]
-    #[deprecated(
-        since = "3.0.0",
-        note = "Maybe clap::Parser would fit your use case? (Issue #9)"
-    )]
-    pub fn from_yaml(y: &'help Yaml) -> Self {
-        #![allow(deprecated)]
-        let yaml_file_hash = y.as_hash().expect("YAML file must be a hash");
-        // We WANT this to panic on error...so expect() is good.
-        let (name_yaml, yaml) = yaml_file_hash
-            .iter()
-            .next()
-            .expect("There must be one arg in the YAML file");
-        let name_str = name_yaml.as_str().expect("Arg name must be a string");
-        let mut a = Arg::new(name_str);
-
-        for (k, v) in yaml.as_hash().expect("Arg must be a hash") {
-            a = match k.as_str().expect("Arg fields must be strings") {
-                "short" => yaml_to_char!(a, v, short),
-                "long" => yaml_to_str!(a, v, long),
-                "aliases" => yaml_vec_or_str!(a, v, alias),
-                "help" => yaml_to_str!(a, v, help),
-                "long_help" => yaml_to_str!(a, v, long_help),
-                "required" => yaml_to_bool!(a, v, required),
-                "required_if" => yaml_tuple2!(a, v, required_if_eq),
-                "required_ifs" => yaml_tuple2!(a, v, required_if_eq),
-                "takes_value" => yaml_to_bool!(a, v, takes_value),
-                "index" => yaml_to_usize!(a, v, index),
-                "global" => yaml_to_bool!(a, v, global),
-                "multiple" => yaml_to_bool!(a, v, multiple),
-                "hidden" => yaml_to_bool!(a, v, hide),
-                "next_line_help" => yaml_to_bool!(a, v, next_line_help),
-                "group" => yaml_to_str!(a, v, group),
-                "number_of_values" => yaml_to_usize!(a, v, number_of_values),
-                "max_values" => yaml_to_usize!(a, v, max_values),
-                "min_values" => yaml_to_usize!(a, v, min_values),
-                "value_name" => yaml_to_str!(a, v, value_name),
-                "use_delimiter" => yaml_to_bool!(a, v, use_delimiter),
-                "allow_hyphen_values" => yaml_to_bool!(a, v, allow_hyphen_values),
-                "last" => yaml_to_bool!(a, v, last),
-                "require_delimiter" => yaml_to_bool!(a, v, require_delimiter),
-                "value_delimiter" => yaml_to_char!(a, v, value_delimiter),
-                "required_unless" => yaml_to_str!(a, v, required_unless_present),
-                "display_order" => yaml_to_usize!(a, v, display_order),
-                "default_value" => yaml_to_str!(a, v, default_value),
-                "default_value_if" => yaml_tuple3!(a, v, default_value_if),
-                "default_value_ifs" => yaml_tuple3!(a, v, default_value_if),
-                #[cfg(feature = "env")]
-                "env" => yaml_to_str!(a, v, env),
-                "value_names" => yaml_vec_or_str!(a, v, value_name),
-                "groups" => yaml_vec_or_str!(a, v, group),
-                "requires" => yaml_vec_or_str!(a, v, requires),
-                "requires_if" => yaml_tuple2!(a, v, requires_if),
-                "requires_ifs" => yaml_tuple2!(a, v, requires_if),
-                "conflicts_with" => yaml_vec_or_str!(a, v, conflicts_with),
-                "overrides_with" => yaml_to_str!(a, v, overrides_with),
-                "possible_values" => yaml_vec_or_str!(a, v, possible_value),
-                "case_insensitive" => yaml_to_bool!(a, v, ignore_case),
-                "required_unless_one" => yaml_vec!(a, v, required_unless_present_any),
-                "required_unless_all" => yaml_vec!(a, v, required_unless_present_all),
-                s => {
-                    panic!(
-                        "Unknown setting '{}' in YAML file for arg '{}'",
-                        s, name_str
-                    )
-                }
-            }
-        }
-
-        a
-    }
-
-    /// Deprecated in [Issue #8](https://github.com/epage/clapng/issues/8), see [`arg!`][crate::arg!].
-    #[deprecated(since = "3.0.0", note = "Replaced with `arg!`")]
-    pub fn from_usage(u: &'help str) -> Self {
-        UsageParser::from_usage(u).parse()
-    }
-
-    pub(crate) fn generated(mut self) -> Self {
-        self.provider = ArgProvider::Generated;
-        self
     }
 
     /// Set the identifier used for referencing this argument in the clap API.
@@ -707,636 +409,206 @@ impl<'help> Arg<'help> {
         self
     }
 
-    /// Sets the description of the argument for short help (`-h`).
+    /// Specifies the index of a positional argument **starting at** 1.
     ///
-    /// Typically, this is a short (one line) description of the arg.
+    /// **NOTE:** The index refers to position according to **other positional argument**. It does
+    /// not define position in the argument list as a whole.
     ///
-    /// If [`Arg::long_help`] is not specified, this message will be displayed for `--help`.
+    /// **NOTE:** You can optionally leave off the `index` method, and the index will be
+    /// assigned in order of evaluation. Utilizing the `index` method allows for setting
+    /// indexes out of order
     ///
-    /// **NOTE:** Only `Arg::help` is used in completion script generation in order to be concise
+    /// **NOTE:** This is only meant to be used for positional arguments and shouldn't to be used
+    /// with [`Arg::short`] or [`Arg::long`].
+    ///
+    /// **NOTE:** When utilized with [`Arg::multiple_values(true)`], only the **last** positional argument
+    /// may be defined as multiple (i.e. with the highest index)
+    ///
+    /// # Panics
+    ///
+    /// [`App`] will [`panic!`] if indexes are skipped (such as defining `index(1)` and `index(3)`
+    /// but not `index(2)`, or a positional argument is defined as multiple and is not the highest
+    /// index
     ///
     /// # Examples
     ///
-    /// Any valid UTF-8 is allowed in the help text. The one exception is when one wishes to
-    /// include a newline in the help text and have the following text be properly aligned with all
-    /// the other help text.
-    ///
-    /// Setting `help` displays a short message to the side of the argument when the user passes
-    /// `-h` or `--help` (by default).
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::new("config")
+    ///     .index(1)
+    /// # ;
+    /// ```
     ///
     /// ```rust
     /// # use clap::{App, Arg};
     /// let m = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .long("config")
-    ///         .help("Some help text describing the --config arg"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--help"
-    ///     ]);
-    /// ```
-    ///
-    /// The above example displays
-    ///
-    /// ```notrust
-    /// helptest
-    ///
-    /// USAGE:
-    ///    helptest [OPTIONS]
-    ///
-    /// OPTIONS:
-    ///     --config     Some help text describing the --config arg
-    /// -h, --help       Print help information
-    /// -V, --version    Print version information
-    /// ```
-    /// [`Arg::long_help`]: Arg::long_help()
-    #[inline]
-    pub fn help(mut self, h: &'help str) -> Self {
-        self.help = Some(h);
-        self
-    }
-
-    /// Sets the description of the argument for long help (`--help`).
-    ///
-    /// Typically this a more detailed (multi-line) message
-    /// that describes the arg.
-    ///
-    /// If [`Arg::help`] is not specified, this message will be displayed for `-h`.
-    ///
-    /// **NOTE:** Only [`Arg::help`] is used in completion script generation in order to be concise
-    ///
-    /// # Examples
-    ///
-    /// Any valid UTF-8 is allowed in the help text. The one exception is when one wishes to
-    /// include a newline in the help text and have the following text be properly aligned with all
-    /// the other help text.
-    ///
-    /// Setting `help` displays a short message to the side of the argument when the user passes
-    /// `-h` or `--help` (by default).
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .long("config")
-    ///         .long_help(
-    /// "The config file used by the myprog must be in JSON format
-    /// with only valid keys and may not contain other nonsense
-    /// that cannot be read by this program. Obviously I'm going on
-    /// and on, so I'll stop now."))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--help"
-    ///     ]);
-    /// ```
-    ///
-    /// The above example displays
-    ///
-    /// ```text
-    /// prog
-    ///
-    /// USAGE:
-    ///     prog [OPTIONS]
-    ///
-    /// OPTIONS:
-    ///         --config
-    ///             The config file used by the myprog must be in JSON format
-    ///             with only valid keys and may not contain other nonsense
-    ///             that cannot be read by this program. Obviously I'm going on
-    ///             and on, so I'll stop now.
-    ///
-    ///     -h, --help
-    ///             Print help information
-    ///
-    ///     -V, --version
-    ///             Print version information
-    /// ```
-    /// [`Arg::help`]: Arg::help()
-    #[inline]
-    pub fn long_help(mut self, h: &'help str) -> Self {
-        self.long_help = Some(h);
-        self
-    }
-
-    /// Set this arg as [required] as long as the specified argument is not present at runtime.
-    ///
-    /// **Pro Tip:** Using `Arg::required_unless_present` implies [`Arg::required`] and is therefore not
-    /// mandatory to also set.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("config")
-    ///     .required_unless_present("debug")
-    /// # ;
-    /// ```
-    ///
-    /// In the following example, the required argument is *not* provided,
-    /// but it's not an error because the `unless` arg has been supplied.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .required_unless_present("dbg")
-    ///         .takes_value(true)
-    ///         .long("config"))
-    ///     .arg(Arg::new("dbg")
-    ///         .long("debug"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--debug"
-    ///     ]);
-    ///
-    /// assert!(res.is_ok());
-    /// ```
-    ///
-    /// Setting `Arg::required_unless_present(name)` and *not* supplying `name` or this arg is an error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .required_unless_present("dbg")
-    ///         .takes_value(true)
-    ///         .long("config"))
-    ///     .arg(Arg::new("dbg")
-    ///         .long("debug"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-    /// ```
-    /// [required]: Arg::required()
-    pub fn required_unless_present<T: Key>(mut self, arg_id: T) -> Self {
-        self.r_unless.push(arg_id.into());
-        self
-    }
-
-    /// Deprecated, replaced with [`Arg::required_unless_present`]
-    #[deprecated(since = "3.0.0", note = "Replaced with `Arg::required_unless_present`")]
-    pub fn required_unless<T: Key>(self, arg_id: T) -> Self {
-        self.required_unless_present(arg_id)
-    }
-
-    /// Sets this arg as [required] unless *all* of the specified arguments are present at runtime.
-    ///
-    /// In other words, parsing will succeed only if user either
-    /// * supplies the `self` arg.
-    /// * supplies *all* of the `names` arguments.
-    ///
-    /// **NOTE:** If you wish for this argument to only be required unless *any of* these args are
-    /// present see [`Arg::required_unless_present_any`]
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("config")
-    ///     .required_unless_present_all(&["cfg", "dbg"])
-    /// # ;
-    /// ```
-    ///
-    /// In the following example, the required argument is *not* provided, but it's not an error
-    /// because *all* of the `names` args have been supplied.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .required_unless_present_all(&["dbg", "infile"])
-    ///         .takes_value(true)
-    ///         .long("config"))
-    ///     .arg(Arg::new("dbg")
-    ///         .long("debug"))
-    ///     .arg(Arg::new("infile")
-    ///         .short('i')
-    ///         .takes_value(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--debug", "-i", "file"
-    ///     ]);
-    ///
-    /// assert!(res.is_ok());
-    /// ```
-    ///
-    /// Setting [`Arg::required_unless_present_all(names)`] and *not* supplying
-    /// either *all* of `unless` args or the `self` arg is an error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .required_unless_present_all(&["dbg", "infile"])
-    ///         .takes_value(true)
-    ///         .long("config"))
-    ///     .arg(Arg::new("dbg")
-    ///         .long("debug"))
-    ///     .arg(Arg::new("infile")
-    ///         .short('i')
-    ///         .takes_value(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-    /// ```
-    /// [required]: Arg::required()
-    /// [`Arg::required_unless_present_any`]: Arg::required_unless_present_any()
-    /// [`Arg::required_unless_present_all(names)`]: Arg::required_unless_present_all()
-    pub fn required_unless_present_all<T, I>(mut self, names: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-        T: Key,
-    {
-        self.r_unless_all.extend(names.into_iter().map(Id::from));
-        self
-    }
-
-    /// Deprecated, replaced with [`Arg::required_unless_present_all`]
-    #[deprecated(
-        since = "3.0.0",
-        note = "Replaced with `Arg::required_unless_present_all`"
-    )]
-    pub fn required_unless_all<T, I>(self, names: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-        T: Key,
-    {
-        self.required_unless_present_all(names)
-    }
-
-    /// Sets this arg as [required] unless *any* of the specified arguments are present at runtime.
-    ///
-    /// In other words, parsing will succeed only if user either
-    /// * supplies the `self` arg.
-    /// * supplies *one or more* of the `unless` arguments.
-    ///
-    /// **NOTE:** If you wish for this argument to be required unless *all of* these args are
-    /// present see [`Arg::required_unless_present_all`]
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("config")
-    ///     .required_unless_present_any(&["cfg", "dbg"])
-    /// # ;
-    /// ```
-    ///
-    /// Setting [`Arg::required_unless_present_any(names)`] requires that the argument be used at runtime
-    /// *unless* *at least one of* the args in `names` are present. In the following example, the
-    /// required argument is *not* provided, but it's not an error because one the `unless` args
-    /// have been supplied.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .required_unless_present_any(&["dbg", "infile"])
-    ///         .takes_value(true)
-    ///         .long("config"))
-    ///     .arg(Arg::new("dbg")
-    ///         .long("debug"))
-    ///     .arg(Arg::new("infile")
-    ///         .short('i')
-    ///         .takes_value(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--debug"
-    ///     ]);
-    ///
-    /// assert!(res.is_ok());
-    /// ```
-    ///
-    /// Setting [`Arg::required_unless_present_any(names)`] and *not* supplying *at least one of* `names`
-    /// or this arg is an error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .required_unless_present_any(&["dbg", "infile"])
-    ///         .takes_value(true)
-    ///         .long("config"))
-    ///     .arg(Arg::new("dbg")
-    ///         .long("debug"))
-    ///     .arg(Arg::new("infile")
-    ///         .short('i')
-    ///         .takes_value(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-    /// ```
-    /// [required]: Arg::required()
-    /// [`Arg::required_unless_present_any(names)`]: Arg::required_unless_present_any()
-    /// [`Arg::required_unless_present_all`]: Arg::required_unless_present_all()
-    pub fn required_unless_present_any<T, I>(mut self, names: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-        T: Key,
-    {
-        self.r_unless.extend(names.into_iter().map(Id::from));
-        self
-    }
-
-    /// Deprecated, replaced with [`Arg::required_unless_present_any`]
-    #[deprecated(
-        since = "3.0.0",
-        note = "Replaced with `Arg::required_unless_present_any`"
-    )]
-    pub fn required_unless_one<T, I>(self, names: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-        T: Key,
-    {
-        self.required_unless_present_any(names)
-    }
-
-    /// This argument is mutually exclusive with the specified argument.
-    ///
-    /// **NOTE:** Conflicting rules take precedence over being required by default. Conflict rules
-    /// only need to be set for one of the two arguments, they do not need to be set for each.
-    ///
-    /// **NOTE:** Defining a conflict is two-way, but does *not* need to defined for both arguments
-    /// (i.e. if A conflicts with B, defining A.conflicts_with(B) is sufficient. You do not
-    /// need to also do B.conflicts_with(A))
-    ///
-    /// **NOTE:** [`Arg::conflicts_with_all(names)`] allows specifying an argument which conflicts with more than one argument.
-    ///
-    /// **NOTE** [`Arg::exclusive(true)`] allows specifying an argument which conflicts with every other argument.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("config")
-    ///     .conflicts_with("debug")
-    /// # ;
-    /// ```
-    ///
-    /// Setting conflicting argument, and having both arguments present at runtime is an error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .takes_value(true)
-    ///         .conflicts_with("debug")
-    ///         .long("config"))
-    ///     .arg(Arg::new("debug")
-    ///         .long("debug"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--debug", "--config", "file.conf"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
-    /// ```
-    ///
-    /// [`Arg::conflicts_with_all(names)`]: Arg::conflicts_with_all()
-    /// [`Arg::exclusive(true)`]: Arg::exclusive()
-    pub fn conflicts_with<T: Key>(mut self, arg_id: T) -> Self {
-        self.blacklist.push(arg_id.into());
-        self
-    }
-
-    /// This argument is mutually exclusive with the specified arguments.
-    ///
-    /// See [`Arg::conflicts_with`].
-    ///
-    /// **NOTE:** Conflicting rules take precedence over being required by default. Conflict rules
-    /// only need to be set for one of the two arguments, they do not need to be set for each.
-    ///
-    /// **NOTE:** Defining a conflict is two-way, but does *not* need to defined for both arguments
-    /// (i.e. if A conflicts with B, defining A.conflicts_with(B) is sufficient. You do not need
-    /// need to also do B.conflicts_with(A))
-    ///
-    /// **NOTE:** [`Arg::exclusive(true)`] allows specifying an argument which conflicts with every other argument.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("config")
-    ///     .conflicts_with_all(&["debug", "input"])
-    /// # ;
-    /// ```
-    ///
-    /// Setting conflicting argument, and having any of the arguments present at runtime with a
-    /// conflicting argument is an error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .takes_value(true)
-    ///         .conflicts_with_all(&["debug", "input"])
-    ///         .long("config"))
-    ///     .arg(Arg::new("debug")
-    ///         .long("debug"))
-    ///     .arg(Arg::new("input")
+    ///     .arg(Arg::new("mode")
     ///         .index(1))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--config", "file.conf", "file.txt"
+    ///     .arg(Arg::new("debug")
+    ///         .long("debug"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--debug", "fast"
     ///     ]);
     ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
+    /// assert!(m.is_present("mode"));
+    /// assert_eq!(m.value_of("mode"), Some("fast")); // notice index(1) means "first positional"
+    ///                                               // *not* first argument
     /// ```
-    /// [`Arg::conflicts_with`]: Arg::conflicts_with()
-    /// [`Arg::exclusive(true)`]: Arg::exclusive()
-    pub fn conflicts_with_all(mut self, names: &[&str]) -> Self {
-        self.blacklist.extend(names.iter().map(Id::from));
+    /// [`Arg::short`]: Arg::short()
+    /// [`Arg::long`]: Arg::long()
+    /// [`Arg::multiple_values(true)`]: Arg::multiple_values()
+    /// [`panic!`]: https://doc.rust-lang.org/std/macro.panic!.html
+    /// [`App`]: crate::App
+    #[inline]
+    pub fn index(mut self, idx: usize) -> Self {
+        self.index = Some(idx);
         self
     }
 
-    /// This argument must be passed alone; it conflicts with all other arguments.
+    /// This arg is the last, or final, positional argument (i.e. has the highest
+    /// index) and is *only* able to be accessed via the `--` syntax (i.e. `$ prog args --
+    /// last_arg`).
+    ///
+    /// Even, if no other arguments are left to parse, if the user omits the `--` syntax
+    /// they will receive an [`UnknownArgument`] error. Setting an argument to `.last(true)` also
+    /// allows one to access this arg early using the `--` syntax. Accessing an arg early, even with
+    /// the `--` syntax is otherwise not possible.
+    ///
+    /// **NOTE:** This will change the usage string to look like `$ prog [OPTIONS] [-- <ARG>]` if
+    /// `ARG` is marked as `.last(true)`.
+    ///
+    /// **NOTE:** This setting will imply [`crate::AppSettings::DontCollapseArgsInUsage`] because failing
+    /// to set this can make the usage string very confusing.
+    ///
+    /// **NOTE**: This setting only applies to positional arguments, and has no effect on OPTIONS
+    ///
+    /// **NOTE:** Setting this requires [`Arg::takes_value`]
+    ///
+    /// **CAUTION:** Using this setting *and* having child subcommands is not
+    /// recommended with the exception of *also* using [`crate::AppSettings::ArgsNegateSubcommands`]
+    /// (or [`crate::AppSettings::SubcommandsNegateReqs`] if the argument marked `Last` is also
+    /// marked [`Arg::required`])
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Arg;
+    /// Arg::new("args")
+    ///     .takes_value(true)
+    ///     .last(true)
+    /// # ;
+    /// ```
+    ///
+    /// Setting `last` ensures the arg has the highest [index] of all positional args
+    /// and requires that the `--` syntax be used to access it early.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("first"))
+    ///     .arg(Arg::new("second"))
+    ///     .arg(Arg::new("third")
+    ///         .takes_value(true)
+    ///         .last(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "one", "--", "three"
+    ///     ]);
+    ///
+    /// assert!(res.is_ok());
+    /// let m = res.unwrap();
+    /// assert_eq!(m.value_of("third"), Some("three"));
+    /// assert!(m.value_of("second").is_none());
+    /// ```
+    ///
+    /// Even if the positional argument marked `Last` is the only argument left to parse,
+    /// failing to use the `--` syntax results in an error.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("first"))
+    ///     .arg(Arg::new("second"))
+    ///     .arg(Arg::new("third")
+    ///         .takes_value(true)
+    ///         .last(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "one", "two", "three"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// ```
+    /// [index]: Arg::index()
+    /// [`UnknownArgument`]: crate::ErrorKind::UnknownArgument
+    #[inline]
+    pub fn last(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::Last)
+        } else {
+            self.unset_setting(ArgSettings::Last)
+        }
+    }
+
+    /// Specifies that the argument must be present.
+    ///
+    /// Required by default means it is required, when no other conflicting rules or overrides have
+    /// been evaluated. Conflicting rules take precedence over being required.
+    ///
+    /// **Pro tip:** Flags (i.e. not positional, or arguments that take values) shouldn't be
+    /// required by default. This is because if a flag were to be required, it should simply be
+    /// implied. No additional information is required from user. Flags by their very nature are
+    /// simply boolean on/off switches. The only time a user *should* be required to use a flag
+    /// is if the operation is destructive in nature, and the user is essentially proving to you,
+    /// "Yes, I know what I'm doing."
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use clap::Arg;
     /// Arg::new("config")
-    ///     .exclusive(true)
+    ///     .required(true)
     /// # ;
     /// ```
     ///
-    /// Setting an exclusive argument and having any other arguments present at runtime
-    /// is an error.
+    /// Setting required requires that the argument be used at runtime.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .required(true)
+    ///         .takes_value(true)
+    ///         .long("config"))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--config", "file.conf",
+    ///     ]);
+    ///
+    /// assert!(res.is_ok());
+    /// ```
+    ///
+    /// Setting required and then *not* supplying that argument at runtime is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
-    ///     .arg(Arg::new("exclusive")
+    ///     .arg(Arg::new("cfg")
+    ///         .required(true)
     ///         .takes_value(true)
-    ///         .exclusive(true)
-    ///         .long("exclusive"))
-    ///     .arg(Arg::new("debug")
-    ///         .long("debug"))
-    ///     .arg(Arg::new("input")
-    ///         .index(1))
+    ///         .long("config"))
     ///     .try_get_matches_from(vec![
-    ///         "prog", "--exclusive", "file.conf", "file.txt"
+    ///         "prog"
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
     /// ```
     #[inline]
-    pub fn exclusive(mut self, yes: bool) -> Self {
-        self.exclusive = yes;
-        self
-    }
-
-    /// Sets an overridable argument.
-    ///
-    /// i.e. this argument and the following argument
-    /// will override each other in POSIX style (whichever argument was specified at runtime
-    /// **last** "wins")
-    ///
-    /// **NOTE:** When an argument is overridden it is essentially as if it never was used, any
-    /// conflicts, requirements, etc. are evaluated **after** all "overrides" have been removed
-    ///
-    /// **WARNING:** Positional arguments and options which accept
-    /// [`Arg::multiple_occurrences`] cannot override themselves (or we
-    /// would never be able to advance to the next positional). If a positional
-    /// argument or option with one of the [`Arg::multiple_occurrences`]
-    /// settings lists itself as an override, it is simply ignored.
-    ///
-    /// # Examples
-    ///
-    /// ```rust # use clap::{App, Arg};
-    /// # use clap::{App, arg};
-    /// let m = App::new("prog")
-    ///     .arg(arg!(-f --flag "some flag")
-    ///         .conflicts_with("debug"))
-    ///     .arg(arg!(-d --debug "other flag"))
-    ///     .arg(arg!(-c --color "third flag")
-    ///         .overrides_with("flag"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-f", "-d", "-c"]);
-    ///             //    ^~~~~~~~~~~~^~~~~ flag is overridden by color
-    ///
-    /// assert!(m.is_present("color"));
-    /// assert!(m.is_present("debug")); // even though flag conflicts with debug, it's as if flag
-    ///                                 // was never used because it was overridden with color
-    /// assert!(!m.is_present("flag"));
-    /// ```
-    /// Care must be taken when using this setting, and having an arg override with itself. This
-    /// is common practice when supporting things like shell aliases, config files, etc.
-    /// However, when combined with multiple values, it can get dicy.
-    /// Here is how clap handles such situations:
-    ///
-    /// When a flag overrides itself, it's as if the flag was only ever used once (essentially
-    /// preventing a "Unexpected multiple usage" error):
-    ///
-    /// ```rust
-    /// # use clap::{App, arg};
-    /// let m = App::new("posix")
-    ///             .arg(arg!(--flag  "some flag").overrides_with("flag"))
-    ///             .get_matches_from(vec!["posix", "--flag", "--flag"]);
-    /// assert!(m.is_present("flag"));
-    /// assert_eq!(m.occurrences_of("flag"), 1);
-    /// ```
-    ///
-    /// Making an arg [`Arg::multiple_occurrences`] and override itself
-    /// is essentially meaningless. Therefore clap ignores an override of self
-    /// if it's a flag and it already accepts multiple occurrences.
-    ///
-    /// ```
-    /// # use clap::{App, arg};
-    /// let m = App::new("posix")
-    ///             .arg(arg!(--flag ...  "some flag").overrides_with("flag"))
-    ///             .get_matches_from(vec!["", "--flag", "--flag", "--flag", "--flag"]);
-    /// assert!(m.is_present("flag"));
-    /// assert_eq!(m.occurrences_of("flag"), 4);
-    /// ```
-    ///
-    /// Now notice with options (which *do not* set
-    /// [`Arg::multiple_occurrences`]), it's as if only the last
-    /// occurrence happened.
-    ///
-    /// ```
-    /// # use clap::{App, arg};
-    /// let m = App::new("posix")
-    ///             .arg(arg!(--opt <val> "some option").overrides_with("opt"))
-    ///             .get_matches_from(vec!["", "--opt=some", "--opt=other"]);
-    /// assert!(m.is_present("opt"));
-    /// assert_eq!(m.occurrences_of("opt"), 1);
-    /// assert_eq!(m.value_of("opt"), Some("other"));
-    /// ```
-    ///
-    /// This will also work when [`Arg::multiple_values`] is enabled:
-    ///
-    /// ```
-    /// # use clap::{App, Arg};
-    /// let m = App::new("posix")
-    ///             .arg(
-    ///                 Arg::new("opt")
-    ///                     .long("opt")
-    ///                     .takes_value(true)
-    ///                     .multiple_values(true)
-    ///                     .overrides_with("opt")
-    ///             )
-    ///             .get_matches_from(vec!["", "--opt", "1", "2", "--opt", "3", "4", "5"]);
-    /// assert!(m.is_present("opt"));
-    /// assert_eq!(m.occurrences_of("opt"), 1);
-    /// assert_eq!(m.values_of("opt").unwrap().collect::<Vec<_>>(), &["3", "4", "5"]);
-    /// ```
-    ///
-    /// Just like flags, options with [`Arg::multiple_occurrences`] set
-    /// will ignore the "override self" setting.
-    ///
-    /// ```
-    /// # use clap::{App, arg};
-    /// let m = App::new("posix")
-    ///             .arg(arg!(--opt <val> ... "some option")
-    ///                 .multiple_values(true)
-    ///                 .overrides_with("opt"))
-    ///             .get_matches_from(vec!["", "--opt", "first", "over", "--opt", "other", "val"]);
-    /// assert!(m.is_present("opt"));
-    /// assert_eq!(m.occurrences_of("opt"), 2);
-    /// assert_eq!(m.values_of("opt").unwrap().collect::<Vec<_>>(), &["first", "over", "other", "val"]);
-    /// ```
-    pub fn overrides_with<T: Key>(mut self, arg_id: T) -> Self {
-        self.overrides.push(arg_id.into());
-        self
-    }
-
-    /// Sets multiple mutually overridable arguments by name.
-    ///
-    /// i.e. this argument and the following argument will override each other in POSIX style
-    /// (whichever argument was specified at runtime **last** "wins")
-    ///
-    /// **NOTE:** When an argument is overridden it is essentially as if it never was used, any
-    /// conflicts, requirements, etc. are evaluated **after** all "overrides" have been removed
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, arg};
-    /// let m = App::new("prog")
-    ///     .arg(arg!(-f --flag "some flag")
-    ///         .conflicts_with("color"))
-    ///     .arg(arg!(-d --debug "other flag"))
-    ///     .arg(arg!(-c --color "third flag")
-    ///         .overrides_with_all(&["flag", "debug"]))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-f", "-d", "-c"]);
-    ///             //    ^~~~~~^~~~~~~~~ flag and debug are overridden by color
-    ///
-    /// assert!(m.is_present("color")); // even though flag conflicts with color, it's as if flag
-    ///                                 // and debug were never used because they were overridden
-    ///                                 // with color
-    /// assert!(!m.is_present("debug"));
-    /// assert!(!m.is_present("flag"));
-    /// ```
-    pub fn overrides_with_all<T: Key>(mut self, names: &[T]) -> Self {
-        self.overrides.extend(names.iter().map(Id::from));
-        self
+    pub fn required(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::Required)
+        } else {
+            self.unset_setting(ArgSettings::Required)
+        }
     }
 
     /// Sets an argument that is required when this one is present
@@ -1400,772 +672,480 @@ impl<'help> Arg<'help> {
         self
     }
 
-    /// Require another argument if this arg was present at runtime and its value equals to `val`.
-    ///
-    /// This method takes `value, another_arg` pair. At runtime, clap will check
-    /// if this arg (`self`) is present and its value equals to `val`.
-    /// If it does, `another_arg` will be marked as required.
+    /// This argument must be passed alone; it conflicts with all other arguments.
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use clap::Arg;
     /// Arg::new("config")
-    ///     .requires_if("val", "arg")
+    ///     .exclusive(true)
     /// # ;
     /// ```
     ///
-    /// Setting `Arg::requires_if(val, arg)` requires that the `arg` be used at runtime if the
-    /// defining argument's value is equal to `val`. If the defining argument is anything other than
-    /// `val`, the other argument isn't required.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .takes_value(true)
-    ///         .requires_if("my.cfg", "other")
-    ///         .long("config"))
-    ///     .arg(Arg::new("other"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--config", "some.cfg"
-    ///     ]);
-    ///
-    /// assert!(res.is_ok()); // We didn't use --config=my.cfg, so other wasn't required
-    /// ```
-    ///
-    /// Setting `Arg::requires_if(val, arg)` and setting the value to `val` but *not* supplying
-    /// `arg` is an error.
+    /// Setting an exclusive argument and having any other arguments present at runtime
+    /// is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
+    ///     .arg(Arg::new("exclusive")
     ///         .takes_value(true)
-    ///         .requires_if("my.cfg", "input")
-    ///         .long("config"))
-    ///     .arg(Arg::new("input"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--config", "my.cfg"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-    /// ```
-    /// [`Arg::requires(name)`]: Arg::requires()
-    /// [Conflicting]: Arg::conflicts_with()
-    /// [override]: Arg::overrides_with()
-    pub fn requires_if<T: Key>(mut self, val: &'help str, arg_id: T) -> Self {
-        self.requires.push((Some(val), arg_id.into()));
-        self
-    }
-
-    /// Allows multiple conditional requirements.
-    ///
-    /// The requirement will only become valid if this arg's value equals `val`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("config")
-    ///     .requires_ifs(&[
-    ///         ("val", "arg"),
-    ///         ("other_val", "arg2"),
-    ///     ])
-    /// # ;
-    /// ```
-    ///
-    /// Setting `Arg::requires_ifs(&["val", "arg"])` requires that the `arg` be used at runtime if the
-    /// defining argument's value is equal to `val`. If the defining argument's value is anything other
-    /// than `val`, `arg` isn't required.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .takes_value(true)
-    ///         .requires_ifs(&[
-    ///             ("special.conf", "opt"),
-    ///             ("other.conf", "other"),
-    ///         ])
-    ///         .long("config"))
-    ///     .arg(Arg::new("opt")
-    ///         .long("option")
-    ///         .takes_value(true))
-    ///     .arg(Arg::new("other"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--config", "special.conf"
-    ///     ]);
-    ///
-    /// assert!(res.is_err()); // We  used --config=special.conf so --option <val> is required
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-    /// ```
-    /// [`Arg::requires(name)`]: Arg::requires()
-    /// [Conflicting]: Arg::conflicts_with()
-    /// [override]: Arg::overrides_with()
-    pub fn requires_ifs<T: Key>(mut self, ifs: &[(&'help str, T)]) -> Self {
-        self.requires
-            .extend(ifs.iter().map(|(val, arg)| (Some(*val), Id::from(arg))));
-        self
-    }
-
-    /// This argument is [required] only if the specified `arg` is present at runtime and its value
-    /// equals `val`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("config")
-    ///     .required_if_eq("other_arg", "value")
-    /// # ;
-    /// ```
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .takes_value(true)
-    ///         .required_if_eq("other", "special")
-    ///         .long("config"))
-    ///     .arg(Arg::new("other")
-    ///         .long("other")
-    ///         .takes_value(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--other", "not-special"
-    ///     ]);
-    ///
-    /// assert!(res.is_ok()); // We didn't use --other=special, so "cfg" wasn't required
-    ///
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .takes_value(true)
-    ///         .required_if_eq("other", "special")
-    ///         .long("config"))
-    ///     .arg(Arg::new("other")
-    ///         .long("other")
-    ///         .takes_value(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--other", "special"
-    ///     ]);
-    ///
-    /// // We did use --other=special so "cfg" had become required but was missing.
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-    ///
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .takes_value(true)
-    ///         .required_if_eq("other", "special")
-    ///         .long("config"))
-    ///     .arg(Arg::new("other")
-    ///         .long("other")
-    ///         .takes_value(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--other", "SPECIAL"
-    ///     ]);
-    ///
-    /// // By default, the comparison is case-sensitive, so "cfg" wasn't required
-    /// assert!(res.is_ok());
-    ///
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .takes_value(true)
-    ///         .required_if_eq("other", "special")
-    ///         .long("config"))
-    ///     .arg(Arg::new("other")
-    ///         .long("other")
-    ///         .ignore_case(true)
-    ///         .takes_value(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--other", "SPECIAL"
-    ///     ]);
-    ///
-    /// // However, case-insensitive comparisons can be enabled.  This typically occurs when using Arg::possible_values().
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-    /// ```
-    /// [`Arg::requires(name)`]: Arg::requires()
-    /// [Conflicting]: Arg::conflicts_with()
-    /// [required]: Arg::required()
-    pub fn required_if_eq<T: Key>(mut self, arg_id: T, val: &'help str) -> Self {
-        self.r_ifs.push((arg_id.into(), val));
-        self
-    }
-
-    /// Deprecated, replaced with [`Arg::required_if_eq`]
-    #[deprecated(since = "3.0.0", note = "Replaced with `Arg::required_if_eq`")]
-    pub fn required_if<T: Key>(self, arg_id: T, val: &'help str) -> Self {
-        self.required_if_eq(arg_id, val)
-    }
-
-    /// Specify this argument is [required] based on multiple conditions.
-    ///
-    /// The conditions are set up in a `(arg, val)` style tuple. The requirement will only become
-    /// valid if one of the specified `arg`'s value equals its corresponding `val`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("config")
-    ///     .required_if_eq_any(&[
-    ///         ("extra", "val"),
-    ///         ("option", "spec")
-    ///     ])
-    /// # ;
-    /// ```
-    ///
-    /// Setting `Arg::required_if_eq_any(&[(arg, val)])` makes this arg required if any of the `arg`s
-    /// are used at runtime and it's corresponding value is equal to `val`. If the `arg`'s value is
-    /// anything other than `val`, this argument isn't required.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .required_if_eq_any(&[
-    ///             ("extra", "val"),
-    ///             ("option", "spec")
-    ///         ])
-    ///         .takes_value(true)
-    ///         .long("config"))
-    ///     .arg(Arg::new("extra")
-    ///         .takes_value(true)
-    ///         .long("extra"))
-    ///     .arg(Arg::new("option")
-    ///         .takes_value(true)
-    ///         .long("option"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--option", "other"
-    ///     ]);
-    ///
-    /// assert!(res.is_ok()); // We didn't use --option=spec, or --extra=val so "cfg" isn't required
-    /// ```
-    ///
-    /// Setting `Arg::required_if_eq_any(&[(arg, val)])` and having any of the `arg`s used with its
-    /// value of `val` but *not* using this arg is an error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .required_if_eq_any(&[
-    ///             ("extra", "val"),
-    ///             ("option", "spec")
-    ///         ])
-    ///         .takes_value(true)
-    ///         .long("config"))
-    ///     .arg(Arg::new("extra")
-    ///         .takes_value(true)
-    ///         .long("extra"))
-    ///     .arg(Arg::new("option")
-    ///         .takes_value(true)
-    ///         .long("option"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--option", "spec"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-    /// ```
-    /// [`Arg::requires(name)`]: Arg::requires()
-    /// [Conflicting]: Arg::conflicts_with()
-    /// [required]: Arg::required()
-    pub fn required_if_eq_any<T: Key>(mut self, ifs: &[(T, &'help str)]) -> Self {
-        self.r_ifs
-            .extend(ifs.iter().map(|(id, val)| (Id::from_ref(id), *val)));
-        self
-    }
-
-    /// Deprecated, replaced with [`Arg::required_if_eq_any`]
-    #[deprecated(since = "3.0.0", note = "Replaced with `Arg::required_if_eq_any`")]
-    pub fn required_ifs<T: Key>(self, ifs: &[(T, &'help str)]) -> Self {
-        self.required_if_eq_any(ifs)
-    }
-
-    /// Specify this argument is [required] based on multiple conditions.
-    ///
-    /// The conditions are set up in a `(arg, val)` style tuple. The requirement will only become
-    /// valid if every one of the specified `arg`'s value equals its corresponding `val`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("config")
-    ///     .required_if_eq_all(&[
-    ///         ("extra", "val"),
-    ///         ("option", "spec")
-    ///     ])
-    /// # ;
-    /// ```
-    ///
-    /// Setting `Arg::required_if_eq_all(&[(arg, val)])` makes this arg required if all of the `arg`s
-    /// are used at runtime and every value is equal to its corresponding `val`. If the `arg`'s value is
-    /// anything other than `val`, this argument isn't required.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .required_if_eq_all(&[
-    ///             ("extra", "val"),
-    ///             ("option", "spec")
-    ///         ])
-    ///         .takes_value(true)
-    ///         .long("config"))
-    ///     .arg(Arg::new("extra")
-    ///         .takes_value(true)
-    ///         .long("extra"))
-    ///     .arg(Arg::new("option")
-    ///         .takes_value(true)
-    ///         .long("option"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--option", "spec"
-    ///     ]);
-    ///
-    /// assert!(res.is_ok()); // We didn't use --option=spec --extra=val so "cfg" isn't required
-    /// ```
-    ///
-    /// Setting `Arg::required_if_eq_all(&[(arg, val)])` and having all of the `arg`s used with its
-    /// value of `val` but *not* using this arg is an error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .required_if_eq_all(&[
-    ///             ("extra", "val"),
-    ///             ("option", "spec")
-    ///         ])
-    ///         .takes_value(true)
-    ///         .long("config"))
-    ///     .arg(Arg::new("extra")
-    ///         .takes_value(true)
-    ///         .long("extra"))
-    ///     .arg(Arg::new("option")
-    ///         .takes_value(true)
-    ///         .long("option"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--extra", "val", "--option", "spec"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-    /// ```
-    /// [required]: Arg::required()
-    pub fn required_if_eq_all<T: Key>(mut self, ifs: &[(T, &'help str)]) -> Self {
-        self.r_ifs_all
-            .extend(ifs.iter().map(|(id, val)| (Id::from_ref(id), *val)));
-        self
-    }
-
-    /// Require these arguments names when this one is presen
-    ///
-    /// i.e. when using this argument, the following arguments *must* be present.
-    ///
-    /// **NOTE:** [Conflicting] rules and [override] rules take precedence over being required
-    /// by default.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("config")
-    ///     .requires_all(&["input", "output"])
-    /// # ;
-    /// ```
-    ///
-    /// Setting `Arg::requires_all(&[arg, arg2])` requires that all the arguments be used at
-    /// runtime if the defining argument is used. If the defining argument isn't used, the other
-    /// argument isn't required
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .takes_value(true)
-    ///         .requires("input")
-    ///         .long("config"))
-    ///     .arg(Arg::new("input")
-    ///         .index(1))
-    ///     .arg(Arg::new("output")
-    ///         .index(2))
-    ///     .try_get_matches_from(vec![
-    ///         "prog"
-    ///     ]);
-    ///
-    /// assert!(res.is_ok()); // We didn't use cfg, so input and output weren't required
-    /// ```
-    ///
-    /// Setting `Arg::requires_all(&[arg, arg2])` and *not* supplying all the arguments is an
-    /// error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .takes_value(true)
-    ///         .requires_all(&["input", "output"])
-    ///         .long("config"))
-    ///     .arg(Arg::new("input")
-    ///         .index(1))
-    ///     .arg(Arg::new("output")
-    ///         .index(2))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--config", "file.conf", "in.txt"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// // We didn't use output
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-    /// ```
-    /// [Conflicting]: Arg::conflicts_with()
-    /// [override]: Arg::overrides_with()
-    pub fn requires_all<T: Key>(mut self, names: &[T]) -> Self {
-        self.requires.extend(names.iter().map(|s| (None, s.into())));
-        self
-    }
-
-    /// Specifies the index of a positional argument **starting at** 1.
-    ///
-    /// **NOTE:** The index refers to position according to **other positional argument**. It does
-    /// not define position in the argument list as a whole.
-    ///
-    /// **NOTE:** You can optionally leave off the `index` method, and the index will be
-    /// assigned in order of evaluation. Utilizing the `index` method allows for setting
-    /// indexes out of order
-    ///
-    /// **NOTE:** This is only meant to be used for positional arguments and shouldn't to be used
-    /// with [`Arg::short`] or [`Arg::long`].
-    ///
-    /// **NOTE:** When utilized with [`Arg::multiple_values(true)`], only the **last** positional argument
-    /// may be defined as multiple (i.e. with the highest index)
-    ///
-    /// # Panics
-    ///
-    /// [`App`] will [`panic!`] if indexes are skipped (such as defining `index(1)` and `index(3)`
-    /// but not `index(2)`, or a positional argument is defined as multiple and is not the highest
-    /// index
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// Arg::new("config")
-    ///     .index(1)
-    /// # ;
-    /// ```
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("mode")
-    ///         .index(1))
+    ///         .exclusive(true)
+    ///         .long("exclusive"))
     ///     .arg(Arg::new("debug")
     ///         .long("debug"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--debug", "fast"
+    ///     .arg(Arg::new("input")
+    ///         .index(1))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--exclusive", "file.conf", "file.txt"
     ///     ]);
     ///
-    /// assert!(m.is_present("mode"));
-    /// assert_eq!(m.value_of("mode"), Some("fast")); // notice index(1) means "first positional"
-    ///                                               // *not* first argument
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
     /// ```
-    /// [`Arg::short`]: Arg::short()
-    /// [`Arg::long`]: Arg::long()
-    /// [`Arg::multiple_values(true)`]: Arg::multiple_values()
-    /// [`panic!`]: https://doc.rust-lang.org/std/macro.panic!.html
-    /// [`App`]: crate::App
     #[inline]
-    pub fn index(mut self, idx: usize) -> Self {
-        self.index = Some(idx);
+    pub fn exclusive(mut self, yes: bool) -> Self {
+        self.exclusive = yes;
         self
     }
 
-    /// Sentinel to **stop** parsing multiple values of a give argument.
+    /// Specifies that an argument can be matched to all child [`Subcommand`]s.
     ///
-    /// By default when
-    /// one sets [`multiple_values(true)`] on an argument, clap will continue parsing values for that
-    /// argument until it reaches another valid argument, or one of the other more specific settings
-    /// for multiple values is used (such as [`min_values`], [`max_values`] or
-    /// [`number_of_values`]).
+    /// **NOTE:** Global arguments *only* propagate down, **not** up (to parent commands), however
+    /// their values once a user uses them will be propagated back up to parents. In effect, this
+    /// means one should *define* all global arguments at the top level, however it doesn't matter
+    /// where the user *uses* the global argument.
     ///
-    /// **NOTE:** This setting only applies to [options] and [positional arguments]
+    /// # Examples
     ///
-    /// **NOTE:** When the terminator is passed in on the command line, it is **not** stored as one
-    /// of the values
+    /// Assume an application with two subcommands, and you'd like to define a
+    /// `--verbose` flag that can be called on any of the subcommands and parent, but you don't
+    /// want to clutter the source with three duplicate [`Arg`] definitions.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("verb")
+    ///         .long("verbose")
+    ///         .short('v')
+    ///         .global(true))
+    ///     .subcommand(App::new("test"))
+    ///     .subcommand(App::new("do-stuff"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "do-stuff", "--verbose"
+    ///     ]);
+    ///
+    /// assert_eq!(m.subcommand_name(), Some("do-stuff"));
+    /// let sub_m = m.subcommand_matches("do-stuff").unwrap();
+    /// assert!(sub_m.is_present("verb"));
+    /// ```
+    ///
+    /// [`Subcommand`]: crate::Subcommand
+    /// [`ArgMatches::is_present("flag")`]: ArgMatches::is_present()
+    #[inline]
+    pub fn global(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::Global)
+        } else {
+            self.unset_setting(ArgSettings::Global)
+        }
+    }
+
+    /// Specifies that the argument may appear more than once.
+    ///
+    /// For flags, this results in the number of occurrences of the flag being recorded. For
+    /// example `-ddd` or `-d -d -d` would count as three occurrences. For options or arguments
+    /// that take a value, this *does not* affect how many values they can accept. (i.e. only one
+    /// at a time is allowed)
+    ///
+    /// For example, `--opt val1 --opt val2` is allowed, but `--opt val1 val2` is not.
+    ///
+    /// # Examples
+    ///
+    /// An example with flags
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("verbose")
+    ///         .multiple_occurrences(true)
+    ///         .short('v'))
+    ///     .get_matches_from(vec![
+    ///         "prog", "-v", "-v", "-v"    // note, -vvv would have same result
+    ///     ]);
+    ///
+    /// assert!(m.is_present("verbose"));
+    /// assert_eq!(m.occurrences_of("verbose"), 3);
+    /// ```
+    ///
+    /// An example with options
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("file")
+    ///         .multiple_occurrences(true)
+    ///         .takes_value(true)
+    ///         .short('F'))
+    ///     .get_matches_from(vec![
+    ///         "prog", "-F", "file1", "-F", "file2", "-F", "file3"
+    ///     ]);
+    ///
+    /// assert!(m.is_present("file"));
+    /// assert_eq!(m.occurrences_of("file"), 3);
+    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
+    /// assert_eq!(files, ["file1", "file2", "file3"]);
+    /// ```
+    #[inline]
+    pub fn multiple_occurrences(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::MultipleOccurrences)
+        } else {
+            self.unset_setting(ArgSettings::MultipleOccurrences)
+        }
+    }
+
+    /// The *maximum* number of occurrences for this argument.
+    ///
+    /// For example, if you had a
+    /// `-v` flag and you wanted up to 3 levels of verbosity you would set `.max_occurrences(3)`, and
+    /// this argument would be satisfied if the user provided it once or twice or thrice.
+    ///
+    /// **NOTE:** This implicitly sets [`Arg::multiple_occurrences(true)`] if the value is greater than 1.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::new("verbosity")
+    ///     .short('v')
+    ///     .max_occurrences(3);
+    /// ```
+    ///
+    /// Supplying less than the maximum number of arguments is allowed
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("verbosity")
+    ///         .max_occurrences(3)
+    ///         .short('v'))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "-vvv"
+    ///     ]);
+    ///
+    /// assert!(res.is_ok());
+    /// let m = res.unwrap();
+    /// assert_eq!(m.occurrences_of("verbosity"), 3);
+    /// ```
+    ///
+    /// Supplying more than the maximum number of arguments is an error
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("verbosity")
+    ///         .max_occurrences(2)
+    ///         .short('v'))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "-vvv"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::TooManyOccurrences);
+    /// ```
+    /// [`Arg::multiple_occurrences(true)`]: Arg::multiple_occurrences()
+    #[inline]
+    pub fn max_occurrences(mut self, qty: usize) -> Self {
+        self.max_occurs = Some(qty);
+        if qty > 1 {
+            self.multiple_occurrences(true)
+        } else {
+            self
+        }
+    }
+
+    /// Check if the [`ArgSettings`] variant is currently set on the argument.
+    ///
+    /// [`ArgSettings`]: crate::ArgSettings
+    #[inline]
+    pub fn is_set(&self, s: ArgSettings) -> bool {
+        self.settings.is_set(s)
+    }
+
+    /// Apply a setting to the argument.
+    ///
+    /// See [`ArgSettings`] for a full list of possibilities and examples.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{Arg, ArgSettings};
+    /// Arg::new("config")
+    ///     .setting(ArgSettings::Required)
+    ///     .setting(ArgSettings::TakesValue)
+    /// # ;
+    /// ```
+    ///
+    /// ```no_run
+    /// # use clap::{Arg, ArgSettings};
+    /// Arg::new("config")
+    ///     .setting(ArgSettings::Required | ArgSettings::TakesValue)
+    /// # ;
+    /// ```
+    #[inline]
+    pub fn setting<F>(mut self, setting: F) -> Self
+    where
+        F: Into<ArgFlags>,
+    {
+        self.settings.insert(setting.into());
+        self
+    }
+
+    /// Remove a setting from the argument.
+    ///
+    /// See [`ArgSettings`] for a full list of possibilities and examples.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{Arg, ArgSettings};
+    /// Arg::new("config")
+    ///     .unset_setting(ArgSettings::Required)
+    ///     .unset_setting(ArgSettings::TakesValue)
+    /// # ;
+    /// ```
+    ///
+    /// ```no_run
+    /// # use clap::{Arg, ArgSettings};
+    /// Arg::new("config")
+    ///     .unset_setting(ArgSettings::Required | ArgSettings::TakesValue)
+    /// # ;
+    /// ```
+    #[inline]
+    pub fn unset_setting<F>(mut self, setting: F) -> Self
+    where
+        F: Into<ArgFlags>,
+    {
+        self.settings.remove(setting.into());
+        self
+    }
+}
+
+/// Value handling
+impl<'help> Arg<'help> {
+    /// Specifies that the argument takes a value at run time.
+    ///
+    /// **NOTE:** values for arguments may be specified in any of the following methods
+    ///
+    /// - Using a space such as `-o value` or `--option value`
+    /// - Using an equals and no space such as `-o=value` or `--option=value`
+    /// - Use a short and no space such as `-ovalue`
+    ///
+    /// **NOTE:** By default, args which allow [multiple values] are delimited by commas, meaning
+    /// `--option=val1,val2,val3` is three values for the `--option` argument. If you wish to
+    /// change the delimiter to another character you can use [`Arg::value_delimiter(char)`],
+    /// alternatively you can turn delimiting values **OFF** by using
+    /// [`Arg::use_delimiter(false)`][Arg::use_delimiter]
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use clap::{App, Arg};
-    /// Arg::new("vals")
-    ///     .takes_value(true)
-    ///     .multiple_values(true)
-    ///     .value_terminator(";")
-    /// # ;
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("mode")
+    ///         .long("mode")
+    ///         .takes_value(true))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--mode", "fast"
+    ///     ]);
+    ///
+    /// assert!(m.is_present("mode"));
+    /// assert_eq!(m.value_of("mode"), Some("fast"));
+    /// ```
+    /// [`Arg::value_delimiter(char)`]: Arg::value_delimiter()
+    /// [multiple values]: Arg::multiple_values
+    #[inline]
+    pub fn takes_value(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::TakesValue)
+        } else {
+            self.unset_setting(ArgSettings::TakesValue)
+        }
+    }
+
+    /// Specifies that the argument may have an unknown number of values
+    ///
+    /// Without any other settings, this argument may appear only *once*.
+    ///
+    /// For example, `--opt val1 val2` is allowed, but `--opt val1 val2 --opt val3` is not.
+    ///
+    /// **NOTE:** Setting this requires [`Arg::takes_value`].
+    ///
+    /// **WARNING:**
+    ///
+    /// Setting `multiple_values` for an argument that takes a value, but with no other details can
+    /// be dangerous in some circumstances. Because multiple values are allowed,
+    /// `--option val1 val2 val3` is perfectly valid. Be careful when designing a CLI where
+    /// positional arguments are *also* expected as `clap` will continue parsing *values* until one
+    /// of the following happens:
+    ///
+    /// - It reaches the [maximum number of values]
+    /// - It reaches a [specific number of values]
+    /// - It finds another flag or option (i.e. something that starts with a `-`)
+    /// - It reaches a [value terminator][Arg::value_terminator] is reached
+    ///
+    /// Alternatively, [require a delimiter between values][Arg::require_delimiter].
+    ///
+    /// **WARNING:**
+    ///
+    /// When using args with `multiple_values` and [`subcommands`], one needs to consider the
+    /// possibility of an argument value being the same as a valid subcommand. By default `clap` will
+    /// parse the argument in question as a value *only if* a value is possible at that moment.
+    /// Otherwise it will be parsed as a subcommand. In effect, this means using `multiple_values` with no
+    /// additional parameters and a value that coincides with a subcommand name, the subcommand
+    /// cannot be called unless another argument is passed between them.
+    ///
+    /// As an example, consider a CLI with an option `--ui-paths=<paths>...` and subcommand `signer`
+    ///
+    /// The following would be parsed as values to `--ui-paths`.
+    ///
+    /// ```text
+    /// $ program --ui-paths path1 path2 signer
     /// ```
     ///
-    /// The following example uses two arguments, a sequence of commands, and the location in which
-    /// to perform them
+    /// This is because `--ui-paths` accepts multiple values. `clap` will continue parsing values
+    /// until another argument is reached and it knows `--ui-paths` is done parsing.
+    ///
+    /// By adding additional parameters to `--ui-paths` we can solve this issue. Consider adding
+    /// [`Arg::number_of_values(1)`] or using *only* [`Arg::multiple_occurrences`]. The following are all
+    /// valid, and `signer` is parsed as a subcommand in the first case, but a value in the second
+    /// case.
+    ///
+    /// ```text
+    /// $ program --ui-paths path1 signer
+    /// $ program --ui-paths path1 --ui-paths signer signer
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// An example with options
     ///
     /// ```rust
     /// # use clap::{App, Arg};
     /// let m = App::new("prog")
-    ///     .arg(Arg::new("cmds")
+    ///     .arg(Arg::new("file")
     ///         .takes_value(true)
     ///         .multiple_values(true)
-    ///         .allow_hyphen_values(true)
-    ///         .value_terminator(";"))
-    ///     .arg(Arg::new("location"))
+    ///         .short('F'))
     ///     .get_matches_from(vec![
-    ///         "prog", "find", "-type", "f", "-name", "special", ";", "/home/clap"
+    ///         "prog", "-F", "file1", "file2", "file3"
     ///     ]);
-    /// let cmds: Vec<_> = m.values_of("cmds").unwrap().collect();
-    /// assert_eq!(&cmds, &["find", "-type", "f", "-name", "special"]);
-    /// assert_eq!(m.value_of("location"), Some("/home/clap"));
+    ///
+    /// assert!(m.is_present("file"));
+    /// assert_eq!(m.occurrences_of("file"), 1); // notice only one occurrence
+    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
+    /// assert_eq!(files, ["file1", "file2", "file3"]);
     /// ```
-    /// [options]: Arg::takes_value()
-    /// [positional arguments]: Arg::index()
-    /// [`multiple_values(true)`]: Arg::multiple_values()
-    /// [`min_values`]: Arg::min_values()
-    /// [`number_of_values`]: Arg::number_of_values()
-    /// [`max_values`]: Arg::max_values()
+    ///
+    /// Although `multiple_values` has been specified, we cannot use the argument more than once.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("file")
+    ///         .takes_value(true)
+    ///         .multiple_values(true)
+    ///         .short('F'))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "-F", "file1", "-F", "file2", "-F", "file3"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnexpectedMultipleUsage)
+    /// ```
+    ///
+    /// A common mistake is to define an option which allows multiple values, and a positional
+    /// argument.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("file")
+    ///         .takes_value(true)
+    ///         .multiple_values(true)
+    ///         .short('F'))
+    ///     .arg(Arg::new("word")
+    ///         .index(1))
+    ///     .get_matches_from(vec![
+    ///         "prog", "-F", "file1", "file2", "file3", "word"
+    ///     ]);
+    ///
+    /// assert!(m.is_present("file"));
+    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
+    /// assert_eq!(files, ["file1", "file2", "file3", "word"]); // wait...what?!
+    /// assert!(!m.is_present("word")); // but we clearly used word!
+    /// ```
+    ///
+    /// The problem is `clap` doesn't know when to stop parsing values for "files". This is further
+    /// compounded by if we'd said `word -F file1 file2` it would have worked fine, so it would
+    /// appear to only fail sometimes...not good!
+    ///
+    /// A solution for the example above is to limit how many values with a [maximum], or [specific]
+    /// number, or to say [`Arg::multiple_occurrences`] is ok, but multiple values is not.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("file")
+    ///         .takes_value(true)
+    ///         .multiple_occurrences(true)
+    ///         .short('F'))
+    ///     .arg(Arg::new("word")
+    ///         .index(1))
+    ///     .get_matches_from(vec![
+    ///         "prog", "-F", "file1", "-F", "file2", "-F", "file3", "word"
+    ///     ]);
+    ///
+    /// assert!(m.is_present("file"));
+    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
+    /// assert_eq!(files, ["file1", "file2", "file3"]);
+    /// assert!(m.is_present("word"));
+    /// assert_eq!(m.value_of("word"), Some("word"));
+    /// ```
+    ///
+    /// As a final example, let's fix the above error and get a pretty message to the user :)
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("file")
+    ///         .takes_value(true)
+    ///         .multiple_occurrences(true)
+    ///         .short('F'))
+    ///     .arg(Arg::new("word")
+    ///         .index(1))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "-F", "file1", "file2", "file3", "word"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// ```
+    ///
+    /// [`subcommands`]: crate::App::subcommand()
+    /// [`Arg::number_of_values(1)`]: Arg::number_of_values()
+    /// [maximum number of values]: Arg::max_values()
+    /// [specific number of values]: Arg::number_of_values()
+    /// [maximum]: Arg::max_values()
+    /// [specific]: Arg::number_of_values()
     #[inline]
-    pub fn value_terminator(mut self, term: &'help str) -> Self {
-        self.terminator = Some(term);
-        self.takes_value(true)
-    }
-
-    /// Possible values for this argument.
-    ///
-    /// At runtime, `clap` verifies that
-    /// only one of the specified values was used, or fails with an error message.
-    ///
-    /// **NOTE:** This setting only applies to [options] and [positional arguments]
-    ///
-    /// **NOTE:** You can use both strings directly or use [`PossibleValue`] if you want more control
-    /// over single possible values.
-    ///
-    /// See also [hide_possible_values][Arg::hide_possible_values].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// Arg::new("mode")
-    ///     .takes_value(true)
-    ///     .possible_values(["fast", "slow", "medium"])
-    /// # ;
-    /// ```
-    /// The same using [`PossibleValue`]:
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, PossibleValue};
-    /// Arg::new("mode").takes_value(true).possible_values([
-    ///     PossibleValue::new("fast"),
-    /// // value with a help text
-    ///     PossibleValue::new("slow").help("not that fast"),
-    /// // value that is hidden from completion and help text
-    ///     PossibleValue::new("medium").hide(true),
-    /// ])
-    /// # ;
-    /// ```
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("mode")
-    ///         .long("mode")
-    ///         .takes_value(true)
-    ///         .possible_values(["fast", "slow", "medium"]))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--mode", "fast"
-    ///     ]);
-    /// assert!(m.is_present("mode"));
-    /// assert_eq!(m.value_of("mode"), Some("fast"));
-    /// ```
-    ///
-    /// The next example shows a failed parse from using a value which wasn't defined as one of the
-    /// possible values.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("mode")
-    ///         .long("mode")
-    ///         .takes_value(true)
-    ///         .possible_values(["fast", "slow", "medium"]))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--mode", "wrong"
-    ///     ]);
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::InvalidValue);
-    /// ```
-    /// [options]: Arg::takes_value()
-    /// [positional arguments]: Arg::index()
-    pub fn possible_values<I, T>(mut self, values: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<PossibleValue<'help>>,
-    {
-        self.possible_vals
-            .extend(values.into_iter().map(|value| value.into()));
-        self.takes_value(true)
-    }
-
-    /// Add a possible value for this argument.
-    ///
-    /// At runtime, `clap` verifies that only one of the specified values was used, or fails with
-    /// error message.
-    ///
-    /// **NOTE:** This setting only applies to [options] and [positional arguments]
-    ///
-    /// **NOTE:** You can use both strings directly or use [`PossibleValue`] if you want more control
-    /// over single possible values.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// Arg::new("mode")
-    ///     .takes_value(true)
-    ///     .possible_value("fast")
-    ///     .possible_value("slow")
-    ///     .possible_value("medium")
-    /// # ;
-    /// ```
-    /// The same using [`PossibleValue`]:
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, PossibleValue};
-    /// Arg::new("mode").takes_value(true)
-    ///     .possible_value(PossibleValue::new("fast"))
-    /// // value with a help text
-    ///     .possible_value(PossibleValue::new("slow").help("not that fast"))
-    /// // value that is hidden from completion and help text
-    ///     .possible_value(PossibleValue::new("medium").hide(true))
-    /// # ;
-    /// ```
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("mode")
-    ///         .long("mode")
-    ///         .takes_value(true)
-    ///         .possible_value("fast")
-    ///         .possible_value("slow")
-    ///         .possible_value("medium"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--mode", "fast"
-    ///     ]);
-    /// assert!(m.is_present("mode"));
-    /// assert_eq!(m.value_of("mode"), Some("fast"));
-    /// ```
-    ///
-    /// The next example shows a failed parse from using a value which wasn't defined as one of the
-    /// possible values.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("mode")
-    ///         .long("mode")
-    ///         .takes_value(true)
-    ///         .possible_value("fast")
-    ///         .possible_value("slow")
-    ///         .possible_value("medium"))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--mode", "wrong"
-    ///     ]);
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::InvalidValue);
-    /// ```
-    /// [options]: Arg::takes_value()
-    /// [positional arguments]: Arg::index()
-    pub fn possible_value<T>(mut self, value: T) -> Self
-    where
-        T: Into<PossibleValue<'help>>,
-    {
-        self.possible_vals.push(value.into());
-        self.takes_value(true)
-    }
-
-    /// The name of the [`ArgGroup`] the argument belongs to.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// Arg::new("debug")
-    ///     .long("debug")
-    ///     .group("mode")
-    /// # ;
-    /// ```
-    ///
-    /// Multiple arguments can be a member of a single group and then the group checked as if it
-    /// was one of said arguments.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("debug")
-    ///         .long("debug")
-    ///         .group("mode"))
-    ///     .arg(Arg::new("verbose")
-    ///         .long("verbose")
-    ///         .group("mode"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--debug"
-    ///     ]);
-    /// assert!(m.is_present("mode"));
-    /// ```
-    ///
-    /// [`ArgGroup`]: crate::ArgGroup
-    pub fn group<T: Key>(mut self, group_id: T) -> Self {
-        self.groups.push(group_id.into());
-        self
-    }
-
-    /// The names of [`ArgGroup`]'s the argument belongs to.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// Arg::new("debug")
-    ///     .long("debug")
-    ///     .groups(&["mode", "verbosity"])
-    /// # ;
-    /// ```
-    ///
-    /// Arguments can be members of multiple groups and then the group checked as if it
-    /// was one of said arguments.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("debug")
-    ///         .long("debug")
-    ///         .groups(&["mode", "verbosity"]))
-    ///     .arg(Arg::new("verbose")
-    ///         .long("verbose")
-    ///         .groups(&["mode", "verbosity"]))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--debug"
-    ///     ]);
-    /// assert!(m.is_present("mode"));
-    /// assert!(m.is_present("verbosity"));
-    /// ```
-    ///
-    /// [`ArgGroup`]: crate::ArgGroup
-    pub fn groups<T: Key>(mut self, group_ids: &[T]) -> Self {
-        self.groups.extend(group_ids.iter().map(Id::from));
-        self
+    pub fn multiple_values(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::MultipleValues)
+        } else {
+            self.unset_setting(ArgSettings::MultipleValues)
+        }
     }
 
     /// The number of values allowed for this argument.
@@ -2213,44 +1193,274 @@ impl<'help> Arg<'help> {
         self.takes_value(true).multiple_values(true)
     }
 
-    /// The argument's values can be invalid UTF-8 and should *not* be treated as an error.
+    /// The *maximum* number of values are for this argument.
     ///
-    /// **NOTE:** Using argument values with invalid UTF-8 code points requires using
-    /// [`ArgMatches::value_of_os`], [`ArgMatches::values_of_os`], [`ArgMatches::value_of_lossy`],
-    /// or [`ArgMatches::values_of_lossy`] for those particular arguments which may contain invalid
-    /// UTF-8 values.
+    /// For example, if you had a
+    /// `-f <file>` argument where you wanted up to 3 'files' you would set `.max_values(3)`, and
+    /// this argument would be satisfied if the user provided, 1, 2, or 3 values.
     ///
-    /// **NOTE:** Setting this requires [`Arg::takes_value`]
+    /// **NOTE:** This does *not* implicitly set [`Arg::multiple_occurrences(true)`]. This is because
+    /// `-o val -o val` is multiple occurrences but a single value and `-o val1 val2` is a single
+    /// occurrence with multiple values. For positional arguments this **does** set
+    /// [`Arg::multiple_occurrences(true)`] because there is no way to determine the difference between multiple
+    /// occurrences and multiple values.
     ///
     /// # Examples
     ///
-    #[cfg_attr(not(unix), doc = " ```ignore")]
-    #[cfg_attr(unix, doc = " ```rust")]
+    /// ```rust
     /// # use clap::{App, Arg};
-    /// use std::ffi::OsString;
-    /// use std::os::unix::ffi::{OsStrExt,OsStringExt};
-    /// let r = App::new("myprog")
-    ///     .arg(Arg::new("arg").allow_invalid_utf8(true))
+    /// Arg::new("file")
+    ///     .short('f')
+    ///     .max_values(3);
+    /// ```
+    ///
+    /// Supplying less than the maximum number of values is allowed
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("file")
+    ///         .takes_value(true)
+    ///         .max_values(3)
+    ///         .short('F'))
     ///     .try_get_matches_from(vec![
-    ///         OsString::from("myprog"),
-    ///         OsString::from_vec(vec![0xe9])
+    ///         "prog", "-F", "file1", "file2"
     ///     ]);
     ///
-    /// assert!(r.is_ok());
-    /// let m = r.unwrap();
-    /// assert_eq!(m.value_of_os("arg").unwrap().as_bytes(), &[0xe9]);
+    /// assert!(res.is_ok());
+    /// let m = res.unwrap();
+    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
+    /// assert_eq!(files, ["file1", "file2"]);
     /// ```
-    /// [`ArgMatches::value_of_os`]: crate::ArgMatches::value_of_os()
-    /// [`ArgMatches::values_of_os`]: crate::ArgMatches::values_of_os()
-    /// [`ArgMatches::value_of_lossy`]: crate::ArgMatches::value_of_lossy()
-    /// [`ArgMatches::values_of_lossy`]: crate::ArgMatches::values_of_lossy()
+    ///
+    /// Supplying more than the maximum number of values is an error
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("file")
+    ///         .takes_value(true)
+    ///         .max_values(2)
+    ///         .short('F'))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "-F", "file1", "file2", "file3"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// ```
+    /// [`Arg::multiple_occurrences(true)`]: Arg::multiple_occurrences()
     #[inline]
-    pub fn allow_invalid_utf8(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::AllowInvalidUtf8)
-        } else {
-            self.unset_setting(ArgSettings::AllowInvalidUtf8)
-        }
+    pub fn max_values(mut self, qty: usize) -> Self {
+        self.max_vals = Some(qty);
+        self.takes_value(true).multiple_values(true)
+    }
+
+    /// The *minimum* number of values for this argument.
+    ///
+    /// For example, if you had a
+    /// `-f <file>` argument where you wanted at least 2 'files' you would set
+    /// `.min_values(2)`, and this argument would be satisfied if the user provided, 2 or more
+    /// values.
+    ///
+    /// **NOTE:** This does not implicitly set [`Arg::multiple_occurrences(true)`]. This is because
+    /// `-o val -o val` is multiple occurrences but a single value and `-o val1 val2` is a single
+    /// occurrence with multiple values. For positional arguments this **does** set
+    /// [`Arg::multiple_occurrences(true)`] because there is no way to determine the difference between multiple
+    /// occurrences and multiple values.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::new("file")
+    ///     .short('f')
+    ///     .min_values(3);
+    /// ```
+    ///
+    /// Supplying more than the minimum number of values is allowed
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("file")
+    ///         .takes_value(true)
+    ///         .min_values(2)
+    ///         .short('F'))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "-F", "file1", "file2", "file3"
+    ///     ]);
+    ///
+    /// assert!(res.is_ok());
+    /// let m = res.unwrap();
+    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
+    /// assert_eq!(files, ["file1", "file2", "file3"]);
+    /// ```
+    ///
+    /// Supplying less than the minimum number of values is an error
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("file")
+    ///         .takes_value(true)
+    ///         .min_values(2)
+    ///         .short('F'))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "-F", "file1"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::TooFewValues);
+    /// ```
+    /// [`Arg::multiple_occurrences(true)`]: Arg::multiple_occurrences()
+    #[inline]
+    pub fn min_values(mut self, qty: usize) -> Self {
+        self.min_vals = Some(qty);
+        self.takes_value(true).multiple_values(true)
+    }
+
+    /// Placeholder for the argument's value in the help message / usage.
+    ///
+    /// This name is cosmetic only; the name is **not** used to access arguments.
+    /// This setting can be very helpful when describing the type of input the user should be
+    /// using, such as `FILE`, `INTERFACE`, etc. Although not required, it's somewhat convention to
+    /// use all capital letters for the value name.
+    ///
+    /// **NOTE:** implicitly sets [`Arg::takes_value(true)`]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::new("cfg")
+    ///     .long("config")
+    ///     .value_name("FILE")
+    /// # ;
+    /// ```
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("config")
+    ///         .long("config")
+    ///         .value_name("FILE")
+    ///         .help("Some help text"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    /// Running the above program produces the following output
+    ///
+    /// ```text
+    /// valnames
+    ///
+    /// USAGE:
+    ///    valnames [OPTIONS]
+    ///
+    /// OPTIONS:
+    ///     --config <FILE>     Some help text
+    ///     -h, --help          Print help information
+    ///     -V, --version       Print version information
+    /// ```
+    /// [option]: Arg::takes_value()
+    /// [positional]: Arg::index()
+    /// [`Arg::takes_value(true)`]: Arg::takes_value()
+    #[inline]
+    pub fn value_name(self, name: &'help str) -> Self {
+        self.value_names(&[name])
+    }
+
+    /// Placeholders for the argument's values in the help message / usage.
+    ///
+    /// These names are cosmetic only, used for help and usage strings only. The names are **not**
+    /// used to access arguments. The values of the arguments are accessed in numeric order (i.e.
+    /// if you specify two names `one` and `two` `one` will be the first matched value, `two` will
+    /// be the second).
+    ///
+    /// This setting can be very helpful when describing the type of input the user should be
+    /// using, such as `FILE`, `INTERFACE`, etc. Although not required, it's somewhat convention to
+    /// use all capital letters for the value name.
+    ///
+    /// **Pro Tip:** It may help to use [`Arg::next_line_help(true)`] if there are long, or
+    /// multiple value names in order to not throw off the help text alignment of all options.
+    ///
+    /// **NOTE:** implicitly sets [`Arg::takes_value(true)`] and [`Arg::multiple_values(true)`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::new("speed")
+    ///     .short('s')
+    ///     .value_names(&["fast", "slow"]);
+    /// ```
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("io")
+    ///         .long("io-files")
+    ///         .value_names(&["INFILE", "OUTFILE"]))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    ///
+    /// Running the above program produces the following output
+    ///
+    /// ```text
+    /// valnames
+    ///
+    /// USAGE:
+    ///    valnames [OPTIONS]
+    ///
+    /// OPTIONS:
+    ///     -h, --help                       Print help information
+    ///     --io-files <INFILE> <OUTFILE>    Some help text
+    ///     -V, --version                    Print version information
+    /// ```
+    /// [`Arg::next_line_help(true)`]: Arg::next_line_help()
+    /// [`Arg::number_of_values`]: Arg::number_of_values()
+    /// [`Arg::takes_value(true)`]: Arg::takes_value()
+    /// [`Arg::multiple_values(true)`]: Arg::multiple_values()
+    pub fn value_names(mut self, names: &[&'help str]) -> Self {
+        self.val_names = names.to_vec();
+        self.takes_value(true)
+    }
+
+    /// Provide the shell a hint about how to complete this argument.
+    ///
+    /// See [`ValueHint`][crate::ValueHint] for more information.
+    ///
+    /// **NOTE:** implicitly sets [`Arg::takes_value(true)`].
+    ///
+    /// For example, to take a username as argument:
+    ///
+    /// ```
+    /// # use clap::{Arg, ValueHint};
+    /// Arg::new("user")
+    ///     .short('u')
+    ///     .long("user")
+    ///     .value_hint(ValueHint::Username);
+    /// ```
+    ///
+    /// To take a full command line and its arguments (for example, when writing a command wrapper):
+    ///
+    /// ```
+    /// # use clap::{App, AppSettings, Arg, ValueHint};
+    /// App::new("prog")
+    ///     .setting(AppSettings::TrailingVarArg)
+    ///     .arg(
+    ///         Arg::new("command")
+    ///             .takes_value(true)
+    ///             .multiple_values(true)
+    ///             .value_hint(ValueHint::CommandWithArguments)
+    ///     );
+    /// ```
+    pub fn value_hint(mut self, value_hint: ValueHint) -> Self {
+        self.value_hint = value_hint;
+        self.takes_value(true)
     }
 
     /// Perform a custom validation on the argument value.
@@ -2413,190 +1623,483 @@ impl<'help> Arg<'help> {
         })
     }
 
-    /// The *maximum* number of occurrences for this argument.
+    /// Add a possible value for this argument.
     ///
-    /// For example, if you had a
-    /// `-v` flag and you wanted up to 3 levels of verbosity you would set `.max_occurrences(3)`, and
-    /// this argument would be satisfied if the user provided it once or twice or thrice.
+    /// At runtime, `clap` verifies that only one of the specified values was used, or fails with
+    /// error message.
     ///
-    /// **NOTE:** This implicitly sets [`Arg::multiple_occurrences(true)`] if the value is greater than 1.
+    /// **NOTE:** This setting only applies to [options] and [positional arguments]
+    ///
+    /// **NOTE:** You can use both strings directly or use [`PossibleValue`] if you want more control
+    /// over single possible values.
+    ///
     /// # Examples
     ///
     /// ```rust
     /// # use clap::{App, Arg};
-    /// Arg::new("verbosity")
-    ///     .short('v')
-    ///     .max_occurrences(3);
+    /// Arg::new("mode")
+    ///     .takes_value(true)
+    ///     .possible_value("fast")
+    ///     .possible_value("slow")
+    ///     .possible_value("medium")
+    /// # ;
     /// ```
+    /// The same using [`PossibleValue`]:
     ///
-    /// Supplying less than the maximum number of arguments is allowed
+    /// ```rust
+    /// # use clap::{App, Arg, PossibleValue};
+    /// Arg::new("mode").takes_value(true)
+    ///     .possible_value(PossibleValue::new("fast"))
+    /// // value with a help text
+    ///     .possible_value(PossibleValue::new("slow").help("not that fast"))
+    /// // value that is hidden from completion and help text
+    ///     .possible_value(PossibleValue::new("medium").hide(true))
+    /// # ;
+    /// ```
     ///
     /// ```rust
     /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("verbosity")
-    ///         .max_occurrences(3)
-    ///         .short('v'))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "-vvv"
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("mode")
+    ///         .long("mode")
+    ///         .takes_value(true)
+    ///         .possible_value("fast")
+    ///         .possible_value("slow")
+    ///         .possible_value("medium"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--mode", "fast"
     ///     ]);
-    ///
-    /// assert!(res.is_ok());
-    /// let m = res.unwrap();
-    /// assert_eq!(m.occurrences_of("verbosity"), 3);
+    /// assert!(m.is_present("mode"));
+    /// assert_eq!(m.value_of("mode"), Some("fast"));
     /// ```
     ///
-    /// Supplying more than the maximum number of arguments is an error
+    /// The next example shows a failed parse from using a value which wasn't defined as one of the
+    /// possible values.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
-    ///     .arg(Arg::new("verbosity")
-    ///         .max_occurrences(2)
-    ///         .short('v'))
+    ///     .arg(Arg::new("mode")
+    ///         .long("mode")
+    ///         .takes_value(true)
+    ///         .possible_value("fast")
+    ///         .possible_value("slow")
+    ///         .possible_value("medium"))
     ///     .try_get_matches_from(vec![
-    ///         "prog", "-vvv"
+    ///         "prog", "--mode", "wrong"
+    ///     ]);
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::InvalidValue);
+    /// ```
+    /// [options]: Arg::takes_value()
+    /// [positional arguments]: Arg::index()
+    pub fn possible_value<T>(mut self, value: T) -> Self
+    where
+        T: Into<PossibleValue<'help>>,
+    {
+        self.possible_vals.push(value.into());
+        self.takes_value(true)
+    }
+
+    /// Possible values for this argument.
+    ///
+    /// At runtime, `clap` verifies that
+    /// only one of the specified values was used, or fails with an error message.
+    ///
+    /// **NOTE:** This setting only applies to [options] and [positional arguments]
+    ///
+    /// **NOTE:** You can use both strings directly or use [`PossibleValue`] if you want more control
+    /// over single possible values.
+    ///
+    /// See also [hide_possible_values][Arg::hide_possible_values].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::new("mode")
+    ///     .takes_value(true)
+    ///     .possible_values(["fast", "slow", "medium"])
+    /// # ;
+    /// ```
+    /// The same using [`PossibleValue`]:
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, PossibleValue};
+    /// Arg::new("mode").takes_value(true).possible_values([
+    ///     PossibleValue::new("fast"),
+    /// // value with a help text
+    ///     PossibleValue::new("slow").help("not that fast"),
+    /// // value that is hidden from completion and help text
+    ///     PossibleValue::new("medium").hide(true),
+    /// ])
+    /// # ;
+    /// ```
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("mode")
+    ///         .long("mode")
+    ///         .takes_value(true)
+    ///         .possible_values(["fast", "slow", "medium"]))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--mode", "fast"
+    ///     ]);
+    /// assert!(m.is_present("mode"));
+    /// assert_eq!(m.value_of("mode"), Some("fast"));
+    /// ```
+    ///
+    /// The next example shows a failed parse from using a value which wasn't defined as one of the
+    /// possible values.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("mode")
+    ///         .long("mode")
+    ///         .takes_value(true)
+    ///         .possible_values(["fast", "slow", "medium"]))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--mode", "wrong"
+    ///     ]);
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::InvalidValue);
+    /// ```
+    /// [options]: Arg::takes_value()
+    /// [positional arguments]: Arg::index()
+    pub fn possible_values<I, T>(mut self, values: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<PossibleValue<'help>>,
+    {
+        self.possible_vals
+            .extend(values.into_iter().map(|value| value.into()));
+        self.takes_value(true)
+    }
+
+    /// Match values against [`Arg::possible_values`] without matching case.
+    ///
+    /// When other arguments are conditionally required based on the
+    /// value of a case-insensitive argument, the equality check done
+    /// by [`Arg::required_if_eq`], [`Arg::required_if_eq_any`], or
+    /// [`Arg::required_if_eq_all`] is case-insensitive.
+    ///
+    ///
+    /// **NOTE:** Setting this requires [`Arg::takes_value`]
+    ///
+    /// **NOTE:** To do unicode case folding, enable the `unicode` feature flag.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("pv")
+    ///     .arg(Arg::new("option")
+    ///         .long("--option")
+    ///         .takes_value(true)
+    ///         .ignore_case(true)
+    ///         .possible_value("test123"))
+    ///     .get_matches_from(vec![
+    ///         "pv", "--option", "TeSt123",
     ///     ]);
     ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::TooManyOccurrences);
+    /// assert!(m.value_of("option").unwrap().eq_ignore_ascii_case("test123"));
     /// ```
-    /// [`Arg::multiple_occurrences(true)`]: Arg::multiple_occurrences()
+    ///
+    /// This setting also works when multiple values can be defined:
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("pv")
+    ///     .arg(Arg::new("option")
+    ///         .short('o')
+    ///         .long("--option")
+    ///         .takes_value(true)
+    ///         .ignore_case(true)
+    ///         .multiple_values(true)
+    ///         .possible_values(&["test123", "test321"]))
+    ///     .get_matches_from(vec![
+    ///         "pv", "--option", "TeSt123", "teST123", "tESt321"
+    ///     ]);
+    ///
+    /// let matched_vals = m.values_of("option").unwrap().collect::<Vec<_>>();
+    /// assert_eq!(&*matched_vals, &["TeSt123", "teST123", "tESt321"]);
+    /// ```
     #[inline]
-    pub fn max_occurrences(mut self, qty: usize) -> Self {
-        self.max_occurs = Some(qty);
-        if qty > 1 {
-            self.multiple_occurrences(true)
+    pub fn ignore_case(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::IgnoreCase)
         } else {
-            self
+            self.unset_setting(ArgSettings::IgnoreCase)
         }
     }
 
-    /// The *maximum* number of values are for this argument.
+    /// Allows values which start with a leading hyphen (`-`)
     ///
-    /// For example, if you had a
-    /// `-f <file>` argument where you wanted up to 3 'files' you would set `.max_values(3)`, and
-    /// this argument would be satisfied if the user provided, 1, 2, or 3 values.
+    /// **NOTE:** Setting this requires [`Arg::takes_value`]
     ///
-    /// **NOTE:** This does *not* implicitly set [`Arg::multiple_occurrences(true)`]. This is because
-    /// `-o val -o val` is multiple occurrences but a single value and `-o val1 val2` is a single
-    /// occurrence with multiple values. For positional arguments this **does** set
-    /// [`Arg::multiple_occurrences(true)`] because there is no way to determine the difference between multiple
-    /// occurrences and multiple values.
+    /// **WARNING**: Take caution when using this setting combined with
+    /// [`Arg::multiple_values`], as this becomes ambiguous `$ prog --arg -- -- val`. All
+    /// three `--, --, val` will be values when the user may have thought the second `--` would
+    /// constitute the normal, "Only positional args follow" idiom. To fix this, consider using
+    /// [`Arg::multiple_occurrences`] which only allows a single value at a time.
+    ///
+    /// **WARNING**: When building your CLIs, consider the effects of allowing leading hyphens and
+    /// the user passing in a value that matches a valid short. For example, `prog -opt -F` where
+    /// `-F` is supposed to be a value, yet `-F` is *also* a valid short for another arg.
+    /// Care should be taken when designing these args. This is compounded by the ability to "stack"
+    /// short args. I.e. if `-val` is supposed to be a value, but `-v`, `-a`, and `-l` are all valid
+    /// shorts.
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use clap::{App, Arg};
-    /// Arg::new("file")
-    ///     .short('f')
-    ///     .max_values(3);
-    /// ```
-    ///
-    /// Supplying less than the maximum number of values is allowed
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("file")
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("pat")
     ///         .takes_value(true)
-    ///         .max_values(3)
-    ///         .short('F'))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "-F", "file1", "file2"
+    ///         .allow_hyphen_values(true)
+    ///         .long("pattern"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--pattern", "-file"
     ///     ]);
     ///
-    /// assert!(res.is_ok());
-    /// let m = res.unwrap();
-    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
-    /// assert_eq!(files, ["file1", "file2"]);
+    /// assert_eq!(m.value_of("pat"), Some("-file"));
     /// ```
     ///
-    /// Supplying more than the maximum number of values is an error
+    /// Not setting `Arg::allow_hyphen_values(true)` and supplying a value which starts with a
+    /// hyphen is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
-    ///     .arg(Arg::new("file")
+    ///     .arg(Arg::new("pat")
     ///         .takes_value(true)
-    ///         .max_values(2)
-    ///         .short('F'))
+    ///         .long("pattern"))
     ///     .try_get_matches_from(vec![
-    ///         "prog", "-F", "file1", "file2", "file3"
+    ///         "prog", "--pattern", "-file"
     ///     ]);
     ///
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
     /// ```
-    /// [`Arg::multiple_occurrences(true)`]: Arg::multiple_occurrences()
+    /// [`Arg::number_of_values(1)`]: Arg::number_of_values()
     #[inline]
-    pub fn max_values(mut self, qty: usize) -> Self {
-        self.max_vals = Some(qty);
-        self.takes_value(true).multiple_values(true)
+    pub fn allow_hyphen_values(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::AllowHyphenValues)
+        } else {
+            self.unset_setting(ArgSettings::AllowHyphenValues)
+        }
     }
 
-    /// The *minimum* number of values for this argument.
+    /// The argument's values can be invalid UTF-8 and should *not* be treated as an error.
     ///
-    /// For example, if you had a
-    /// `-f <file>` argument where you wanted at least 2 'files' you would set
-    /// `.min_values(2)`, and this argument would be satisfied if the user provided, 2 or more
-    /// values.
+    /// **NOTE:** Using argument values with invalid UTF-8 code points requires using
+    /// [`ArgMatches::value_of_os`], [`ArgMatches::values_of_os`], [`ArgMatches::value_of_lossy`],
+    /// or [`ArgMatches::values_of_lossy`] for those particular arguments which may contain invalid
+    /// UTF-8 values.
     ///
-    /// **NOTE:** This does not implicitly set [`Arg::multiple_occurrences(true)`]. This is because
-    /// `-o val -o val` is multiple occurrences but a single value and `-o val1 val2` is a single
-    /// occurrence with multiple values. For positional arguments this **does** set
-    /// [`Arg::multiple_occurrences(true)`] because there is no way to determine the difference between multiple
-    /// occurrences and multiple values.
+    /// **NOTE:** Setting this requires [`Arg::takes_value`]
     ///
     /// # Examples
     ///
-    /// ```rust
+    #[cfg_attr(not(unix), doc = " ```ignore")]
+    #[cfg_attr(unix, doc = " ```rust")]
     /// # use clap::{App, Arg};
-    /// Arg::new("file")
-    ///     .short('f')
-    ///     .min_values(3);
-    /// ```
-    ///
-    /// Supplying more than the minimum number of values is allowed
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("file")
-    ///         .takes_value(true)
-    ///         .min_values(2)
-    ///         .short('F'))
+    /// use std::ffi::OsString;
+    /// use std::os::unix::ffi::{OsStrExt,OsStringExt};
+    /// let r = App::new("myprog")
+    ///     .arg(Arg::new("arg").allow_invalid_utf8(true))
     ///     .try_get_matches_from(vec![
-    ///         "prog", "-F", "file1", "file2", "file3"
+    ///         OsString::from("myprog"),
+    ///         OsString::from_vec(vec![0xe9])
     ///     ]);
     ///
-    /// assert!(res.is_ok());
-    /// let m = res.unwrap();
-    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
-    /// assert_eq!(files, ["file1", "file2", "file3"]);
+    /// assert!(r.is_ok());
+    /// let m = r.unwrap();
+    /// assert_eq!(m.value_of_os("arg").unwrap().as_bytes(), &[0xe9]);
     /// ```
+    /// [`ArgMatches::value_of_os`]: crate::ArgMatches::value_of_os()
+    /// [`ArgMatches::values_of_os`]: crate::ArgMatches::values_of_os()
+    /// [`ArgMatches::value_of_lossy`]: crate::ArgMatches::value_of_lossy()
+    /// [`ArgMatches::values_of_lossy`]: crate::ArgMatches::values_of_lossy()
+    #[inline]
+    pub fn allow_invalid_utf8(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::AllowInvalidUtf8)
+        } else {
+            self.unset_setting(ArgSettings::AllowInvalidUtf8)
+        }
+    }
+
+    /// Don't allow an argument to accept explicitly empty values.
     ///
-    /// Supplying less than the minimum number of values is an error
+    /// An empty value must be specified at the command line with an explicit `""`, `''`, or
+    /// `--option=`
+    ///
+    /// **NOTE:** By default empty values are allowed.
+    ///
+    /// **NOTE:** Setting this requires [`Arg::takes_value`].
+    ///
+    /// # Examples
+    ///
+    /// The default is allowing empty values.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
-    ///     .arg(Arg::new("file")
-    ///         .takes_value(true)
-    ///         .min_values(2)
-    ///         .short('F'))
+    ///     .arg(Arg::new("cfg")
+    ///         .long("config")
+    ///         .short('v')
+    ///         .takes_value(true))
     ///     .try_get_matches_from(vec![
-    ///         "prog", "-F", "file1"
+    ///         "prog", "--config="
+    ///     ]);
+    ///
+    /// assert!(res.is_ok());
+    /// assert_eq!(res.unwrap().value_of("cfg"), Some(""));
+    /// ```
+    ///
+    /// By adding this setting, we can forbid empty values.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .long("config")
+    ///         .short('v')
+    ///         .takes_value(true)
+    ///         .forbid_empty_values(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--config="
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::TooFewValues);
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::EmptyValue);
     /// ```
-    /// [`Arg::multiple_occurrences(true)`]: Arg::multiple_occurrences()
     #[inline]
-    pub fn min_values(mut self, qty: usize) -> Self {
-        self.min_vals = Some(qty);
-        self.takes_value(true).multiple_values(true)
+    pub fn forbid_empty_values(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::ForbidEmptyValues)
+        } else {
+            self.unset_setting(ArgSettings::ForbidEmptyValues)
+        }
+    }
+
+    /// Requires that options use the `--option=val` syntax
+    ///
+    /// i.e. an equals between the option and associated value.
+    ///
+    /// **NOTE:** Setting this requires [`Arg::takes_value`]
+    ///
+    /// # Examples
+    ///
+    /// Setting `require_equals` requires that the option have an equals sign between
+    /// it and the associated value.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .takes_value(true)
+    ///         .require_equals(true)
+    ///         .long("config"))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--config=file.conf"
+    ///     ]);
+    ///
+    /// assert!(res.is_ok());
+    /// ```
+    ///
+    /// Setting `require_equals` and *not* supplying the equals will cause an
+    /// error.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .takes_value(true)
+    ///         .require_equals(true)
+    ///         .long("config"))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--config", "file.conf"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::NoEquals);
+    /// ```
+    #[inline]
+    pub fn require_equals(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::RequireEquals)
+        } else {
+            self.unset_setting(ArgSettings::RequireEquals)
+        }
+    }
+
+    /// Specifies that an argument should allow grouping of multiple values via a
+    /// delimiter.
+    ///
+    /// i.e. should `--option=val1,val2,val3` be parsed as three values (`val1`, `val2`,
+    /// and `val3`) or as a single value (`val1,val2,val3`). Defaults to using `,` (comma) as the
+    /// value delimiter for all arguments that accept values (options and positional arguments)
+    ///
+    /// **NOTE:** When this setting is used, it will default [`Arg::value_delimiter`]
+    /// to the comma `,`.
+    ///
+    /// **NOTE:** Implicitly sets [`Arg::takes_value`]
+    ///
+    /// # Examples
+    ///
+    /// The following example shows the default behavior.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let delims = App::new("prog")
+    ///     .arg(Arg::new("option")
+    ///         .long("option")
+    ///         .use_delimiter(true)
+    ///         .takes_value(true))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--option=val1,val2,val3",
+    ///     ]);
+    ///
+    /// assert!(delims.is_present("option"));
+    /// assert_eq!(delims.occurrences_of("option"), 1);
+    /// assert_eq!(delims.values_of("option").unwrap().collect::<Vec<_>>(), ["val1", "val2", "val3"]);
+    /// ```
+    /// The next example shows the difference when turning delimiters off. This is the default
+    /// behavior
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let nodelims = App::new("prog")
+    ///     .arg(Arg::new("option")
+    ///         .long("option")
+    ///         .takes_value(true))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--option=val1,val2,val3",
+    ///     ]);
+    ///
+    /// assert!(nodelims.is_present("option"));
+    /// assert_eq!(nodelims.occurrences_of("option"), 1);
+    /// assert_eq!(nodelims.value_of("option").unwrap(), "val1,val2,val3");
+    /// ```
+    /// [`Arg::value_delimiter`]: Arg::value_delimiter()
+    #[inline]
+    pub fn use_delimiter(mut self, yes: bool) -> Self {
+        if yes {
+            if self.val_delim.is_none() {
+                self.val_delim = Some(',');
+            }
+            self.takes_value(true)
+                .setting(ArgSettings::UseValueDelimiter)
+        } else {
+            self.val_delim = None;
+            self.unset_setting(ArgSettings::UseValueDelimiter)
+        }
     }
 
     /// Separator between the arguments values, defaults to `,` (comma).
@@ -2628,113 +2131,174 @@ impl<'help> Arg<'help> {
         self.takes_value(true).use_delimiter(true)
     }
 
-    /// Placeholders for the argument's values in the help message / usage.
+    /// Specifies that *multiple values* may only be set using the delimiter.
     ///
-    /// These names are cosmetic only, used for help and usage strings only. The names are **not**
-    /// used to access arguments. The values of the arguments are accessed in numeric order (i.e.
-    /// if you specify two names `one` and `two` `one` will be the first matched value, `two` will
-    /// be the second).
+    /// This means if an option is encountered, and no delimiter is found, it is assumed that no
+    /// additional values for that option follow. This is unlike the default, where it is generally
+    /// assumed that more values will follow regardless of whether or not a delimiter is used.
     ///
-    /// This setting can be very helpful when describing the type of input the user should be
-    /// using, such as `FILE`, `INTERFACE`, etc. Although not required, it's somewhat convention to
-    /// use all capital letters for the value name.
+    /// **NOTE:** The default is `false`.
     ///
-    /// **Pro Tip:** It may help to use [`Arg::next_line_help(true)`] if there are long, or
-    /// multiple value names in order to not throw off the help text alignment of all options.
+    /// **NOTE:** Setting this requires [`Arg::use_delimiter`] and
+    /// [`Arg::takes_value`]
     ///
-    /// **NOTE:** implicitly sets [`Arg::takes_value(true)`] and [`Arg::multiple_values(true)`].
+    /// **NOTE:** It's a good idea to inform the user that use of a delimiter is required, either
+    /// through help text or other means.
     ///
     /// # Examples
     ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// Arg::new("speed")
-    ///     .short('s')
-    ///     .value_names(&["fast", "slow"]);
-    /// ```
+    /// These examples demonstrate what happens when `require_delimiter(true)` is used. Notice
+    /// everything works in this first example, as we use a delimiter, as expected.
     ///
     /// ```rust
     /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("io")
-    ///         .long("io-files")
-    ///         .value_names(&["INFILE", "OUTFILE"]))
+    /// let delims = App::new("prog")
+    ///     .arg(Arg::new("opt")
+    ///         .short('o')
+    ///         .takes_value(true)
+    ///         .use_delimiter(true)
+    ///         .require_delimiter(true)
+    ///         .multiple_values(true))
     ///     .get_matches_from(vec![
-    ///         "prog", "--help"
+    ///         "prog", "-o", "val1,val2,val3",
     ///     ]);
+    ///
+    /// assert!(delims.is_present("opt"));
+    /// assert_eq!(delims.values_of("opt").unwrap().collect::<Vec<_>>(), ["val1", "val2", "val3"]);
     /// ```
     ///
-    /// Running the above program produces the following output
+    /// In this next example, we will *not* use a delimiter. Notice it's now an error.
     ///
-    /// ```text
-    /// valnames
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("opt")
+    ///         .short('o')
+    ///         .takes_value(true)
+    ///         .use_delimiter(true)
+    ///         .require_delimiter(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "-o", "val1", "val2", "val3",
+    ///     ]);
     ///
-    /// USAGE:
-    ///    valnames [OPTIONS]
-    ///
-    /// OPTIONS:
-    ///     -h, --help                       Print help information
-    ///     --io-files <INFILE> <OUTFILE>    Some help text
-    ///     -V, --version                    Print version information
+    /// assert!(res.is_err());
+    /// let err = res.unwrap_err();
+    /// assert_eq!(err.kind, ErrorKind::UnknownArgument);
     /// ```
-    /// [`Arg::next_line_help(true)`]: Arg::next_line_help()
-    /// [`Arg::number_of_values`]: Arg::number_of_values()
-    /// [`Arg::takes_value(true)`]: Arg::takes_value()
-    /// [`Arg::multiple_values(true)`]: Arg::multiple_values()
-    pub fn value_names(mut self, names: &[&'help str]) -> Self {
-        self.val_names = names.to_vec();
-        self.takes_value(true)
+    ///
+    /// What's happening is `-o` is getting `val1`, and because delimiters are required yet none
+    /// were present, it stops parsing `-o`. At this point it reaches `val2` and because no
+    /// positional arguments have been defined, it's an error of an unexpected argument.
+    ///
+    /// In this final example, we contrast the above with `clap`'s default behavior where the above
+    /// is *not* an error.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let delims = App::new("prog")
+    ///     .arg(Arg::new("opt")
+    ///         .short('o')
+    ///         .takes_value(true)
+    ///         .multiple_values(true))
+    ///     .get_matches_from(vec![
+    ///         "prog", "-o", "val1", "val2", "val3",
+    ///     ]);
+    ///
+    /// assert!(delims.is_present("opt"));
+    /// assert_eq!(delims.values_of("opt").unwrap().collect::<Vec<_>>(), ["val1", "val2", "val3"]);
+    /// ```
+    #[inline]
+    pub fn require_delimiter(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::RequireDelimiter)
+        } else {
+            self.unset_setting(ArgSettings::RequireDelimiter)
+        }
     }
 
-    /// Placeholder for the argument's value in the help message / usage.
+    /// Sentinel to **stop** parsing multiple values of a give argument.
     ///
-    /// This name is cosmetic only; the name is **not** used to access arguments.
-    /// This setting can be very helpful when describing the type of input the user should be
-    /// using, such as `FILE`, `INTERFACE`, etc. Although not required, it's somewhat convention to
-    /// use all capital letters for the value name.
+    /// By default when
+    /// one sets [`multiple_values(true)`] on an argument, clap will continue parsing values for that
+    /// argument until it reaches another valid argument, or one of the other more specific settings
+    /// for multiple values is used (such as [`min_values`], [`max_values`] or
+    /// [`number_of_values`]).
     ///
-    /// **NOTE:** implicitly sets [`Arg::takes_value(true)`]
+    /// **NOTE:** This setting only applies to [options] and [positional arguments]
+    ///
+    /// **NOTE:** When the terminator is passed in on the command line, it is **not** stored as one
+    /// of the values
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use clap::{App, Arg};
-    /// Arg::new("cfg")
-    ///     .long("config")
-    ///     .value_name("FILE")
+    /// Arg::new("vals")
+    ///     .takes_value(true)
+    ///     .multiple_values(true)
+    ///     .value_terminator(";")
     /// # ;
     /// ```
     ///
+    /// The following example uses two arguments, a sequence of commands, and the location in which
+    /// to perform them
+    ///
     /// ```rust
     /// # use clap::{App, Arg};
     /// let m = App::new("prog")
-    ///     .arg(Arg::new("config")
-    ///         .long("config")
-    ///         .value_name("FILE")
-    ///         .help("Some help text"))
+    ///     .arg(Arg::new("cmds")
+    ///         .takes_value(true)
+    ///         .multiple_values(true)
+    ///         .allow_hyphen_values(true)
+    ///         .value_terminator(";"))
+    ///     .arg(Arg::new("location"))
     ///     .get_matches_from(vec![
-    ///         "prog", "--help"
+    ///         "prog", "find", "-type", "f", "-name", "special", ";", "/home/clap"
     ///     ]);
+    /// let cmds: Vec<_> = m.values_of("cmds").unwrap().collect();
+    /// assert_eq!(&cmds, &["find", "-type", "f", "-name", "special"]);
+    /// assert_eq!(m.value_of("location"), Some("/home/clap"));
     /// ```
-    /// Running the above program produces the following output
+    /// [options]: Arg::takes_value()
+    /// [positional arguments]: Arg::index()
+    /// [`multiple_values(true)`]: Arg::multiple_values()
+    /// [`min_values`]: Arg::min_values()
+    /// [`number_of_values`]: Arg::number_of_values()
+    /// [`max_values`]: Arg::max_values()
+    #[inline]
+    pub fn value_terminator(mut self, term: &'help str) -> Self {
+        self.terminator = Some(term);
+        self.takes_value(true)
+    }
+
+    /// Consume all following arguments.
+    ///
+    /// Do not be parse them individually, but rather pass them in entirety.
+    ///
+    /// It is worth noting that setting this requires all values to come after a `--` to indicate
+    /// they should all be captured. For example:
     ///
     /// ```text
-    /// valnames
-    ///
-    /// USAGE:
-    ///    valnames [OPTIONS]
-    ///
-    /// OPTIONS:
-    ///     --config <FILE>     Some help text
-    ///     -h, --help          Print help information
-    ///     -V, --version       Print version information
+    /// --foo something -- -v -v -v -b -b -b --baz -q -u -x
     /// ```
-    /// [option]: Arg::takes_value()
-    /// [positional]: Arg::index()
+    ///
+    /// Will result in everything after `--` to be considered one raw argument. This behavior
+    /// may not be exactly what you are expecting and using [`crate::AppSettings::TrailingVarArg`]
+    /// may be more appropriate.
+    ///
+    /// **NOTE:** Implicitly sets [`Arg::takes_value(true)`] [`Arg::multiple_values(true)`],
+    /// [`Arg::allow_hyphen_values(true)`], and [`Arg::last(true)`] when set to `true`.
+    ///
     /// [`Arg::takes_value(true)`]: Arg::takes_value()
+    /// [`Arg::multiple_values(true)`]: Arg::multiple_values()
+    /// [`Arg::allow_hyphen_values(true)`]: Arg::allow_hyphen_values()
+    /// [`Arg::last(true)`]: Arg::last()
     #[inline]
-    pub fn value_name(self, name: &'help str) -> Self {
-        self.value_names(&[name])
+    pub fn raw(self, yes: bool) -> Self {
+        self.takes_value(yes)
+            .multiple_values(yes)
+            .allow_hyphen_values(yes)
+            .last(yes)
     }
 
     /// Value for the argument when not present.
@@ -2947,6 +2511,781 @@ impl<'help> Arg<'help> {
     pub fn default_missing_values_os(mut self, vals: &[&'help OsStr]) -> Self {
         self.default_missing_vals = vals.to_vec();
         self.takes_value(true)
+    }
+
+    /// Read from `name` environment variable when argument is not present.
+    ///
+    /// If it is not present in the environment, then default
+    /// rules will apply.
+    ///
+    /// If user sets the argument in the environment:
+    /// - When [`Arg::takes_value(true)`] is not set, the flag is considered raised.
+    /// - When [`Arg::takes_value(true)`] is set, [`ArgMatches::value_of`] will
+    ///   return value of the environment variable.
+    ///
+    /// If user doesn't set the argument in the environment:
+    /// - When [`Arg::takes_value(true)`] is not set, the flag is considered off.
+    /// - When [`Arg::takes_value(true)`] is set, [`ArgMatches::value_of`] will
+    ///   return the default specified.
+    ///
+    /// # Examples
+    ///
+    /// In this example, we show the variable coming from the environment:
+    ///
+    /// ```rust
+    /// # use std::env;
+    /// # use clap::{App, Arg};
+    ///
+    /// env::set_var("MY_FLAG", "env");
+    ///
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("flag")
+    ///         .long("flag")
+    ///         .env("MY_FLAG")
+    ///         .takes_value(true))
+    ///     .get_matches_from(vec![
+    ///         "prog"
+    ///     ]);
+    ///
+    /// assert_eq!(m.value_of("flag"), Some("env"));
+    /// ```
+    ///
+    /// In this example, because [`Arg::takes_value(false)`] (by default),
+    /// `prog` is a flag that accepts an optional, case-insensitive boolean literal.
+    /// A `false` literal is `n`, `no`, `f`, `false`, `off` or `0`.
+    /// An absent environment variable will also be considered as `false`.
+    /// Anything else will considered as `true`.
+    ///
+    /// ```rust
+    /// # use std::env;
+    /// # use clap::{App, Arg};
+    ///
+    /// env::set_var("TRUE_FLAG", "true");
+    /// env::set_var("FALSE_FLAG", "0");
+    ///
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("true_flag")
+    ///         .long("true_flag")
+    ///         .env("TRUE_FLAG"))
+    ///     .arg(Arg::new("false_flag")
+    ///         .long("false_flag")
+    ///         .env("FALSE_FLAG"))
+    ///     .arg(Arg::new("absent_flag")
+    ///         .long("absent_flag")
+    ///         .env("ABSENT_FLAG"))
+    ///     .get_matches_from(vec![
+    ///         "prog"
+    ///     ]);
+    ///
+    /// assert!(m.is_present("true_flag"));
+    /// assert_eq!(m.value_of("true_flag"), None);
+    /// assert!(!m.is_present("false_flag"));
+    /// assert!(!m.is_present("absent_flag"));
+    /// ```
+    ///
+    /// In this example, we show the variable coming from an option on the CLI:
+    ///
+    /// ```rust
+    /// # use std::env;
+    /// # use clap::{App, Arg};
+    ///
+    /// env::set_var("MY_FLAG", "env");
+    ///
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("flag")
+    ///         .long("flag")
+    ///         .env("MY_FLAG")
+    ///         .takes_value(true))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--flag", "opt"
+    ///     ]);
+    ///
+    /// assert_eq!(m.value_of("flag"), Some("opt"));
+    /// ```
+    ///
+    /// In this example, we show the variable coming from the environment even with the
+    /// presence of a default:
+    ///
+    /// ```rust
+    /// # use std::env;
+    /// # use clap::{App, Arg};
+    ///
+    /// env::set_var("MY_FLAG", "env");
+    ///
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("flag")
+    ///         .long("flag")
+    ///         .env("MY_FLAG")
+    ///         .takes_value(true)
+    ///         .default_value("default"))
+    ///     .get_matches_from(vec![
+    ///         "prog"
+    ///     ]);
+    ///
+    /// assert_eq!(m.value_of("flag"), Some("env"));
+    /// ```
+    ///
+    /// In this example, we show the use of multiple values in a single environment variable:
+    ///
+    /// ```rust
+    /// # use std::env;
+    /// # use clap::{App, Arg};
+    ///
+    /// env::set_var("MY_FLAG_MULTI", "env1,env2");
+    ///
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("flag")
+    ///         .long("flag")
+    ///         .env("MY_FLAG_MULTI")
+    ///         .takes_value(true)
+    ///         .multiple_values(true)
+    ///         .use_delimiter(true))
+    ///     .get_matches_from(vec![
+    ///         "prog"
+    ///     ]);
+    ///
+    /// assert_eq!(m.values_of("flag").unwrap().collect::<Vec<_>>(), vec!["env1", "env2"]);
+    /// ```
+    /// [`ArgMatches::occurrences_of`]: ArgMatches::occurrences_of()
+    /// [`ArgMatches::value_of`]: crate::ArgMatches::value_of()
+    /// [`ArgMatches::is_present`]: ArgMatches::is_present()
+    /// [`Arg::takes_value(true)`]: Arg::takes_value()
+    /// [`Arg::use_delimiter(true)`]: Arg::use_delimiter()
+    #[cfg(feature = "env")]
+    #[inline]
+    pub fn env(self, name: &'help str) -> Self {
+        self.env_os(OsStr::new(name))
+    }
+
+    /// Read from `name` environment variable when argument is not present.
+    ///
+    /// See [`Arg::env`].
+    #[cfg(feature = "env")]
+    #[inline]
+    pub fn env_os(mut self, name: &'help OsStr) -> Self {
+        self.env = Some((name, env::var_os(name)));
+        self
+    }
+}
+
+/// Help
+impl<'help> Arg<'help> {
+    /// Sets the description of the argument for short help (`-h`).
+    ///
+    /// Typically, this is a short (one line) description of the arg.
+    ///
+    /// If [`Arg::long_help`] is not specified, this message will be displayed for `--help`.
+    ///
+    /// **NOTE:** Only `Arg::help` is used in completion script generation in order to be concise
+    ///
+    /// # Examples
+    ///
+    /// Any valid UTF-8 is allowed in the help text. The one exception is when one wishes to
+    /// include a newline in the help text and have the following text be properly aligned with all
+    /// the other help text.
+    ///
+    /// Setting `help` displays a short message to the side of the argument when the user passes
+    /// `-h` or `--help` (by default).
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .long("config")
+    ///         .help("Some help text describing the --config arg"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    ///
+    /// The above example displays
+    ///
+    /// ```notrust
+    /// helptest
+    ///
+    /// USAGE:
+    ///    helptest [OPTIONS]
+    ///
+    /// OPTIONS:
+    ///     --config     Some help text describing the --config arg
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
+    /// ```
+    /// [`Arg::long_help`]: Arg::long_help()
+    #[inline]
+    pub fn help(mut self, h: &'help str) -> Self {
+        self.help = Some(h);
+        self
+    }
+
+    /// Sets the description of the argument for long help (`--help`).
+    ///
+    /// Typically this a more detailed (multi-line) message
+    /// that describes the arg.
+    ///
+    /// If [`Arg::help`] is not specified, this message will be displayed for `-h`.
+    ///
+    /// **NOTE:** Only [`Arg::help`] is used in completion script generation in order to be concise
+    ///
+    /// # Examples
+    ///
+    /// Any valid UTF-8 is allowed in the help text. The one exception is when one wishes to
+    /// include a newline in the help text and have the following text be properly aligned with all
+    /// the other help text.
+    ///
+    /// Setting `help` displays a short message to the side of the argument when the user passes
+    /// `-h` or `--help` (by default).
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .long("config")
+    ///         .long_help(
+    /// "The config file used by the myprog must be in JSON format
+    /// with only valid keys and may not contain other nonsense
+    /// that cannot be read by this program. Obviously I'm going on
+    /// and on, so I'll stop now."))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    ///
+    /// The above example displays
+    ///
+    /// ```text
+    /// prog
+    ///
+    /// USAGE:
+    ///     prog [OPTIONS]
+    ///
+    /// OPTIONS:
+    ///         --config
+    ///             The config file used by the myprog must be in JSON format
+    ///             with only valid keys and may not contain other nonsense
+    ///             that cannot be read by this program. Obviously I'm going on
+    ///             and on, so I'll stop now.
+    ///
+    ///     -h, --help
+    ///             Print help information
+    ///
+    ///     -V, --version
+    ///             Print version information
+    /// ```
+    /// [`Arg::help`]: Arg::help()
+    #[inline]
+    pub fn long_help(mut self, h: &'help str) -> Self {
+        self.long_help = Some(h);
+        self
+    }
+
+    /// Allows custom ordering of args within the help message.
+    ///
+    /// Args with a lower value will be displayed first in the help message. This is helpful when
+    /// one would like to emphasise frequently used args, or prioritize those towards the top of
+    /// the list. Args with duplicate display orders will be displayed in alphabetical order.
+    ///
+    /// **NOTE:** The default is 999 for all arguments.
+    ///
+    /// **NOTE:** This setting is ignored for [positional arguments] which are always displayed in
+    /// [index] order.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("a") // Typically args are grouped alphabetically by name.
+    ///                              // Args without a display_order have a value of 999 and are
+    ///                              // displayed alphabetically with all other 999 valued args.
+    ///         .long("long-option")
+    ///         .short('o')
+    ///         .takes_value(true)
+    ///         .help("Some help and text"))
+    ///     .arg(Arg::new("b")
+    ///         .long("other-option")
+    ///         .short('O')
+    ///         .takes_value(true)
+    ///         .display_order(1)   // In order to force this arg to appear *first*
+    ///                             // all we have to do is give it a value lower than 999.
+    ///                             // Any other args with a value of 1 will be displayed
+    ///                             // alphabetically with this one...then 2 values, then 3, etc.
+    ///         .help("I should be first!"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    ///
+    /// The above example displays the following help message
+    ///
+    /// ```text
+    /// cust-ord
+    ///
+    /// USAGE:
+    ///     cust-ord [OPTIONS]
+    ///
+    /// OPTIONS:
+    ///     -h, --help                Print help information
+    ///     -V, --version             Print version information
+    ///     -O, --other-option <b>    I should be first!
+    ///     -o, --long-option <a>     Some help and text
+    /// ```
+    /// [positional arguments]: Arg::index()
+    /// [index]: Arg::index()
+    #[inline]
+    pub fn display_order(mut self, ord: usize) -> Self {
+        self.disp_ord = Some(ord);
+        self
+    }
+
+    /// Override the [current] help section.
+    ///
+    /// [current]: crate::App::help_heading
+    #[inline]
+    pub fn help_heading<O>(mut self, heading: O) -> Self
+    where
+        O: Into<Option<&'help str>>,
+    {
+        self.help_heading = Some(heading.into());
+        self
+    }
+
+    /// Render the [help][Arg::help] on the line after the argument.
+    ///
+    /// This can be helpful for arguments with very long or complex help messages.
+    /// This can also be helpful for arguments with very long flag names, or many/long value names.
+    ///
+    /// **NOTE:** To apply this setting to all arguments consider using
+    /// [`crate::AppSettings::NextLineHelp`]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("opt")
+    ///         .long("long-option-flag")
+    ///         .short('o')
+    ///         .takes_value(true)
+    ///         .next_line_help(true)
+    ///         .value_names(&["value1", "value2"])
+    ///         .help("Some really long help and complex\n\
+    ///                help that makes more sense to be\n\
+    ///                on a line after the option"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    ///
+    /// The above example displays the following help message
+    ///
+    /// ```text
+    /// nlh
+    ///
+    /// USAGE:
+    ///     nlh [OPTIONS]
+    ///
+    /// OPTIONS:
+    ///     -h, --help       Print help information
+    ///     -V, --version    Print version information
+    ///     -o, --long-option-flag <value1> <value2>
+    ///         Some really long help and complex
+    ///         help that makes more sense to be
+    ///         on a line after the option
+    /// ```
+    #[inline]
+    pub fn next_line_help(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::NextLineHelp)
+        } else {
+            self.unset_setting(ArgSettings::NextLineHelp)
+        }
+    }
+
+    /// Do not display the argument in help message.
+    ///
+    /// **NOTE:** This does **not** hide the argument from usage strings on error
+    ///
+    /// # Examples
+    ///
+    /// Setting `Hidden` will hide the argument when displaying help text
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .long("config")
+    ///         .hide(true)
+    ///         .help("Some help text describing the --config arg"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    ///
+    /// The above example displays
+    ///
+    /// ```text
+    /// helptest
+    ///
+    /// USAGE:
+    ///    helptest [OPTIONS]
+    ///
+    /// OPTIONS:
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
+    /// ```
+    #[inline]
+    pub fn hide(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::Hidden)
+        } else {
+            self.unset_setting(ArgSettings::Hidden)
+        }
+    }
+
+    /// Do not display the [possible values][Arg::possible_values] in the help message.
+    ///
+    /// This is useful for args with many values, or ones which are explained elsewhere in the
+    /// help text.
+    ///
+    /// **NOTE:** Setting this requires [`Arg::takes_value`]
+    ///
+    /// To set this for all arguments, see
+    /// [`AppSettings::HidePossibleValues`][crate::AppSettings::HidePossibleValues].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("mode")
+    ///         .long("mode")
+    ///         .possible_values(["fast", "slow"])
+    ///         .takes_value(true)
+    ///         .hide_possible_values(true));
+    /// ```
+    /// If we were to run the above program with `--help` the `[values: fast, slow]` portion of
+    /// the help text would be omitted.
+    #[inline]
+    pub fn hide_possible_values(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::HidePossibleValues)
+        } else {
+            self.unset_setting(ArgSettings::HidePossibleValues)
+        }
+    }
+
+    /// Do not display the default value of the argument in the help message.
+    ///
+    /// This is useful when default behavior of an arg is explained elsewhere in the help text.
+    ///
+    /// **NOTE:** Setting this requires [`Arg::takes_value`]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("connect")
+    ///     .arg(Arg::new("host")
+    ///         .long("host")
+    ///         .default_value("localhost")
+    ///         .takes_value(true)
+    ///         .hide_default_value(true));
+    ///
+    /// ```
+    ///
+    /// If we were to run the above program with `--help` the `[default: localhost]` portion of
+    /// the help text would be omitted.
+    #[inline]
+    pub fn hide_default_value(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::HideDefaultValue)
+        } else {
+            self.unset_setting(ArgSettings::HideDefaultValue)
+        }
+    }
+
+    /// Do not display in help the environment variable name.
+    ///
+    /// This is useful when the variable option is explained elsewhere in the help text.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("mode")
+    ///         .long("mode")
+    ///         .env("MODE")
+    ///         .takes_value(true)
+    ///         .hide_env(true));
+    /// ```
+    ///
+    /// If we were to run the above program with `--help` the `[env: MODE]` portion of the help
+    /// text would be omitted.
+    #[cfg(feature = "env")]
+    #[inline]
+    pub fn hide_env(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::HideEnv)
+        } else {
+            self.unset_setting(ArgSettings::HideEnv)
+        }
+    }
+
+    /// Do not display in help any values inside the associated ENV variables for the argument.
+    ///
+    /// This is useful when ENV vars contain sensitive values.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("connect")
+    ///     .arg(Arg::new("host")
+    ///         .long("host")
+    ///         .env("CONNECT")
+    ///         .takes_value(true)
+    ///         .hide_env_values(true));
+    ///
+    /// ```
+    ///
+    /// If we were to run the above program with `$ CONNECT=super_secret connect --help` the
+    /// `[default: CONNECT=super_secret]` portion of the help text would be omitted.
+    #[cfg(feature = "env")]
+    #[inline]
+    pub fn hide_env_values(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::HideEnvValues)
+        } else {
+            self.unset_setting(ArgSettings::HideEnvValues)
+        }
+    }
+
+    /// Hides an argument from short help (`-h`).
+    ///
+    /// **NOTE:** This does **not** hide the argument from usage strings on error
+    ///
+    /// **NOTE:** Setting this option will cause next-line-help output style to be used
+    /// when long help (`--help`) is called.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::new("debug")
+    ///     .hide_short_help(true);
+    /// ```
+    ///
+    /// Setting `hide_short_help(true)` will hide the argument when displaying short help text
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .long("config")
+    ///         .hide_short_help(true)
+    ///         .help("Some help text describing the --config arg"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "-h"
+    ///     ]);
+    /// ```
+    ///
+    /// The above example displays
+    ///
+    /// ```text
+    /// helptest
+    ///
+    /// USAGE:
+    ///    helptest [OPTIONS]
+    ///
+    /// OPTIONS:
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
+    /// ```
+    ///
+    /// However, when --help is called
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .long("config")
+    ///         .hide_short_help(true)
+    ///         .help("Some help text describing the --config arg"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    ///
+    /// Then the following would be displayed
+    ///
+    /// ```text
+    /// helptest
+    ///
+    /// USAGE:
+    ///    helptest [OPTIONS]
+    ///
+    /// OPTIONS:
+    ///     --config     Some help text describing the --config arg
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
+    /// ```
+    #[inline]
+    pub fn hide_short_help(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::HiddenShortHelp)
+        } else {
+            self.unset_setting(ArgSettings::HiddenShortHelp)
+        }
+    }
+
+    /// Hides an argument from long help (`--help`).
+    ///
+    /// **NOTE:** This does **not** hide the argument from usage strings on error
+    ///
+    /// **NOTE:** Setting this option will cause next-line-help output style to be used
+    /// when long help (`--help`) is called.
+    ///
+    /// # Examples
+    ///
+    /// Setting `hide_long_help(true)` will hide the argument when displaying long help text
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .long("config")
+    ///         .hide_long_help(true)
+    ///         .help("Some help text describing the --config arg"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    ///
+    /// The above example displays
+    ///
+    /// ```text
+    /// helptest
+    ///
+    /// USAGE:
+    ///    helptest [OPTIONS]
+    ///
+    /// OPTIONS:
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
+    /// ```
+    ///
+    /// However, when -h is called
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .long("config")
+    ///         .hide_long_help(true)
+    ///         .help("Some help text describing the --config arg"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "-h"
+    ///     ]);
+    /// ```
+    ///
+    /// Then the following would be displayed
+    ///
+    /// ```text
+    /// helptest
+    ///
+    /// USAGE:
+    ///    helptest [OPTIONS]
+    ///
+    /// OPTIONS:
+    ///     --config     Some help text describing the --config arg
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
+    /// ```
+    #[inline]
+    pub fn hide_long_help(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::HiddenLongHelp)
+        } else {
+            self.unset_setting(ArgSettings::HiddenLongHelp)
+        }
+    }
+}
+
+/// Advanced argument relations
+impl<'help> Arg<'help> {
+    /// The name of the [`ArgGroup`] the argument belongs to.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::new("debug")
+    ///     .long("debug")
+    ///     .group("mode")
+    /// # ;
+    /// ```
+    ///
+    /// Multiple arguments can be a member of a single group and then the group checked as if it
+    /// was one of said arguments.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("debug")
+    ///         .long("debug")
+    ///         .group("mode"))
+    ///     .arg(Arg::new("verbose")
+    ///         .long("verbose")
+    ///         .group("mode"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--debug"
+    ///     ]);
+    /// assert!(m.is_present("mode"));
+    /// ```
+    ///
+    /// [`ArgGroup`]: crate::ArgGroup
+    pub fn group<T: Key>(mut self, group_id: T) -> Self {
+        self.groups.push(group_id.into());
+        self
+    }
+
+    /// The names of [`ArgGroup`]'s the argument belongs to.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::new("debug")
+    ///     .long("debug")
+    ///     .groups(&["mode", "verbosity"])
+    /// # ;
+    /// ```
+    ///
+    /// Arguments can be members of multiple groups and then the group checked as if it
+    /// was one of said arguments.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::new("debug")
+    ///         .long("debug")
+    ///         .groups(&["mode", "verbosity"]))
+    ///     .arg(Arg::new("verbose")
+    ///         .long("verbose")
+    ///         .groups(&["mode", "verbosity"]))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--debug"
+    ///     ]);
+    /// assert!(m.is_present("mode"));
+    /// assert!(m.is_present("verbosity"));
+    /// ```
+    ///
+    /// [`ArgGroup`]: crate::ArgGroup
+    pub fn groups<T: Key>(mut self, group_ids: &[T]) -> Self {
+        self.groups.extend(group_ids.iter().map(Id::from));
+        self
     }
 
     /// Specifies the value of the argument if `arg` has been used at runtime.
@@ -3184,349 +3523,50 @@ impl<'help> Arg<'help> {
         self
     }
 
-    /// Read from `name` environment variable when argument is not present.
+    /// Set this arg as [required] as long as the specified argument is not present at runtime.
     ///
-    /// If it is not present in the environment, then default
-    /// rules will apply.
-    ///
-    /// If user sets the argument in the environment:
-    /// - When [`Arg::takes_value(true)`] is not set, the flag is considered raised.
-    /// - When [`Arg::takes_value(true)`] is set, [`ArgMatches::value_of`] will
-    ///   return value of the environment variable.
-    ///
-    /// If user doesn't set the argument in the environment:
-    /// - When [`Arg::takes_value(true)`] is not set, the flag is considered off.
-    /// - When [`Arg::takes_value(true)`] is set, [`ArgMatches::value_of`] will
-    ///   return the default specified.
-    ///
-    /// # Examples
-    ///
-    /// In this example, we show the variable coming from the environment:
-    ///
-    /// ```rust
-    /// # use std::env;
-    /// # use clap::{App, Arg};
-    ///
-    /// env::set_var("MY_FLAG", "env");
-    ///
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("flag")
-    ///         .long("flag")
-    ///         .env("MY_FLAG")
-    ///         .takes_value(true))
-    ///     .get_matches_from(vec![
-    ///         "prog"
-    ///     ]);
-    ///
-    /// assert_eq!(m.value_of("flag"), Some("env"));
-    /// ```
-    ///
-    /// In this example, because [`Arg::takes_value(false)`] (by default),
-    /// `prog` is a flag that accepts an optional, case-insensitive boolean literal.
-    /// A `false` literal is `n`, `no`, `f`, `false`, `off` or `0`.
-    /// An absent environment variable will also be considered as `false`.
-    /// Anything else will considered as `true`.
-    ///
-    /// ```rust
-    /// # use std::env;
-    /// # use clap::{App, Arg};
-    ///
-    /// env::set_var("TRUE_FLAG", "true");
-    /// env::set_var("FALSE_FLAG", "0");
-    ///
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("true_flag")
-    ///         .long("true_flag")
-    ///         .env("TRUE_FLAG"))
-    ///     .arg(Arg::new("false_flag")
-    ///         .long("false_flag")
-    ///         .env("FALSE_FLAG"))
-    ///     .arg(Arg::new("absent_flag")
-    ///         .long("absent_flag")
-    ///         .env("ABSENT_FLAG"))
-    ///     .get_matches_from(vec![
-    ///         "prog"
-    ///     ]);
-    ///
-    /// assert!(m.is_present("true_flag"));
-    /// assert_eq!(m.value_of("true_flag"), None);
-    /// assert!(!m.is_present("false_flag"));
-    /// assert!(!m.is_present("absent_flag"));
-    /// ```
-    ///
-    /// In this example, we show the variable coming from an option on the CLI:
-    ///
-    /// ```rust
-    /// # use std::env;
-    /// # use clap::{App, Arg};
-    ///
-    /// env::set_var("MY_FLAG", "env");
-    ///
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("flag")
-    ///         .long("flag")
-    ///         .env("MY_FLAG")
-    ///         .takes_value(true))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--flag", "opt"
-    ///     ]);
-    ///
-    /// assert_eq!(m.value_of("flag"), Some("opt"));
-    /// ```
-    ///
-    /// In this example, we show the variable coming from the environment even with the
-    /// presence of a default:
-    ///
-    /// ```rust
-    /// # use std::env;
-    /// # use clap::{App, Arg};
-    ///
-    /// env::set_var("MY_FLAG", "env");
-    ///
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("flag")
-    ///         .long("flag")
-    ///         .env("MY_FLAG")
-    ///         .takes_value(true)
-    ///         .default_value("default"))
-    ///     .get_matches_from(vec![
-    ///         "prog"
-    ///     ]);
-    ///
-    /// assert_eq!(m.value_of("flag"), Some("env"));
-    /// ```
-    ///
-    /// In this example, we show the use of multiple values in a single environment variable:
-    ///
-    /// ```rust
-    /// # use std::env;
-    /// # use clap::{App, Arg};
-    ///
-    /// env::set_var("MY_FLAG_MULTI", "env1,env2");
-    ///
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("flag")
-    ///         .long("flag")
-    ///         .env("MY_FLAG_MULTI")
-    ///         .takes_value(true)
-    ///         .multiple_values(true)
-    ///         .use_delimiter(true))
-    ///     .get_matches_from(vec![
-    ///         "prog"
-    ///     ]);
-    ///
-    /// assert_eq!(m.values_of("flag").unwrap().collect::<Vec<_>>(), vec!["env1", "env2"]);
-    /// ```
-    /// [`ArgMatches::occurrences_of`]: ArgMatches::occurrences_of()
-    /// [`ArgMatches::value_of`]: crate::ArgMatches::value_of()
-    /// [`ArgMatches::is_present`]: ArgMatches::is_present()
-    /// [`Arg::takes_value(true)`]: Arg::takes_value()
-    /// [`Arg::use_delimiter(true)`]: Arg::use_delimiter()
-    #[cfg(feature = "env")]
-    #[inline]
-    pub fn env(self, name: &'help str) -> Self {
-        self.env_os(OsStr::new(name))
-    }
-
-    /// Read from `name` environment variable when argument is not present.
-    ///
-    /// See [`Arg::env`].
-    #[cfg(feature = "env")]
-    #[inline]
-    pub fn env_os(mut self, name: &'help OsStr) -> Self {
-        self.env = Some((name, env::var_os(name)));
-        self
-    }
-
-    /// Allows custom ordering of args within the help message.
-    ///
-    /// Args with a lower value will be displayed first in the help message. This is helpful when
-    /// one would like to emphasise frequently used args, or prioritize those towards the top of
-    /// the list. Args with duplicate display orders will be displayed in alphabetical order.
-    ///
-    /// **NOTE:** The default is 999 for all arguments.
-    ///
-    /// **NOTE:** This setting is ignored for [positional arguments] which are always displayed in
-    /// [index] order.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("a") // Typically args are grouped alphabetically by name.
-    ///                              // Args without a display_order have a value of 999 and are
-    ///                              // displayed alphabetically with all other 999 valued args.
-    ///         .long("long-option")
-    ///         .short('o')
-    ///         .takes_value(true)
-    ///         .help("Some help and text"))
-    ///     .arg(Arg::new("b")
-    ///         .long("other-option")
-    ///         .short('O')
-    ///         .takes_value(true)
-    ///         .display_order(1)   // In order to force this arg to appear *first*
-    ///                             // all we have to do is give it a value lower than 999.
-    ///                             // Any other args with a value of 1 will be displayed
-    ///                             // alphabetically with this one...then 2 values, then 3, etc.
-    ///         .help("I should be first!"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--help"
-    ///     ]);
-    /// ```
-    ///
-    /// The above example displays the following help message
-    ///
-    /// ```text
-    /// cust-ord
-    ///
-    /// USAGE:
-    ///     cust-ord [OPTIONS]
-    ///
-    /// OPTIONS:
-    ///     -h, --help                Print help information
-    ///     -V, --version             Print version information
-    ///     -O, --other-option <b>    I should be first!
-    ///     -o, --long-option <a>     Some help and text
-    /// ```
-    /// [positional arguments]: Arg::index()
-    /// [index]: Arg::index()
-    #[inline]
-    pub fn display_order(mut self, ord: usize) -> Self {
-        self.disp_ord = Some(ord);
-        self
-    }
-
-    /// This arg is the last, or final, positional argument (i.e. has the highest
-    /// index) and is *only* able to be accessed via the `--` syntax (i.e. `$ prog args --
-    /// last_arg`).
-    ///
-    /// Even, if no other arguments are left to parse, if the user omits the `--` syntax
-    /// they will receive an [`UnknownArgument`] error. Setting an argument to `.last(true)` also
-    /// allows one to access this arg early using the `--` syntax. Accessing an arg early, even with
-    /// the `--` syntax is otherwise not possible.
-    ///
-    /// **NOTE:** This will change the usage string to look like `$ prog [OPTIONS] [-- <ARG>]` if
-    /// `ARG` is marked as `.last(true)`.
-    ///
-    /// **NOTE:** This setting will imply [`crate::AppSettings::DontCollapseArgsInUsage`] because failing
-    /// to set this can make the usage string very confusing.
-    ///
-    /// **NOTE**: This setting only applies to positional arguments, and has no effect on OPTIONS
-    ///
-    /// **NOTE:** Setting this requires [`Arg::takes_value`]
-    ///
-    /// **CAUTION:** Using this setting *and* having child subcommands is not
-    /// recommended with the exception of *also* using [`crate::AppSettings::ArgsNegateSubcommands`]
-    /// (or [`crate::AppSettings::SubcommandsNegateReqs`] if the argument marked `Last` is also
-    /// marked [`Arg::required`])
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::Arg;
-    /// Arg::new("args")
-    ///     .takes_value(true)
-    ///     .last(true)
-    /// # ;
-    /// ```
-    ///
-    /// Setting `last` ensures the arg has the highest [index] of all positional args
-    /// and requires that the `--` syntax be used to access it early.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("first"))
-    ///     .arg(Arg::new("second"))
-    ///     .arg(Arg::new("third")
-    ///         .takes_value(true)
-    ///         .last(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "one", "--", "three"
-    ///     ]);
-    ///
-    /// assert!(res.is_ok());
-    /// let m = res.unwrap();
-    /// assert_eq!(m.value_of("third"), Some("three"));
-    /// assert!(m.value_of("second").is_none());
-    /// ```
-    ///
-    /// Even if the positional argument marked `Last` is the only argument left to parse,
-    /// failing to use the `--` syntax results in an error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("first"))
-    ///     .arg(Arg::new("second"))
-    ///     .arg(Arg::new("third")
-    ///         .takes_value(true)
-    ///         .last(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "one", "two", "three"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
-    /// ```
-    /// [index]: Arg::index()
-    /// [`UnknownArgument`]: crate::ErrorKind::UnknownArgument
-    #[inline]
-    pub fn last(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::Last)
-        } else {
-            self.unset_setting(ArgSettings::Last)
-        }
-    }
-
-    /// Specifies that the argument must be present.
-    ///
-    /// Required by default means it is required, when no other conflicting rules or overrides have
-    /// been evaluated. Conflicting rules take precedence over being required.
-    ///
-    /// **Pro tip:** Flags (i.e. not positional, or arguments that take values) shouldn't be
-    /// required by default. This is because if a flag were to be required, it should simply be
-    /// implied. No additional information is required from user. Flags by their very nature are
-    /// simply boolean on/off switches. The only time a user *should* be required to use a flag
-    /// is if the operation is destructive in nature, and the user is essentially proving to you,
-    /// "Yes, I know what I'm doing."
+    /// **Pro Tip:** Using `Arg::required_unless_present` implies [`Arg::required`] and is therefore not
+    /// mandatory to also set.
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use clap::Arg;
     /// Arg::new("config")
-    ///     .required(true)
+    ///     .required_unless_present("debug")
     /// # ;
     /// ```
     ///
-    /// Setting required requires that the argument be used at runtime.
+    /// In the following example, the required argument is *not* provided,
+    /// but it's not an error because the `unless` arg has been supplied.
     ///
     /// ```rust
     /// # use clap::{App, Arg};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .required(true)
+    ///         .required_unless_present("dbg")
     ///         .takes_value(true)
     ///         .long("config"))
+    ///     .arg(Arg::new("dbg")
+    ///         .long("debug"))
     ///     .try_get_matches_from(vec![
-    ///         "prog", "--config", "file.conf",
+    ///         "prog", "--debug"
     ///     ]);
     ///
     /// assert!(res.is_ok());
     /// ```
     ///
-    /// Setting required and then *not* supplying that argument at runtime is an error.
+    /// Setting `Arg::required_unless_present(name)` and *not* supplying `name` or this arg is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .required(true)
+    ///         .required_unless_present("dbg")
     ///         .takes_value(true)
     ///         .long("config"))
+    ///     .arg(Arg::new("dbg")
+    ///         .long("debug"))
     ///     .try_get_matches_from(vec![
     ///         "prog"
     ///     ]);
@@ -3534,140 +3574,551 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
     /// ```
-    #[inline]
-    pub fn required(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::Required)
-        } else {
-            self.unset_setting(ArgSettings::Required)
-        }
+    /// [required]: Arg::required()
+    pub fn required_unless_present<T: Key>(mut self, arg_id: T) -> Self {
+        self.r_unless.push(arg_id.into());
+        self
     }
 
-    /// Specifies that the argument takes a value at run time.
+    /// Sets this arg as [required] unless *all* of the specified arguments are present at runtime.
     ///
-    /// **NOTE:** values for arguments may be specified in any of the following methods
+    /// In other words, parsing will succeed only if user either
+    /// * supplies the `self` arg.
+    /// * supplies *all* of the `names` arguments.
     ///
-    /// - Using a space such as `-o value` or `--option value`
-    /// - Using an equals and no space such as `-o=value` or `--option=value`
-    /// - Use a short and no space such as `-ovalue`
-    ///
-    /// **NOTE:** By default, args which allow [multiple values] are delimited by commas, meaning
-    /// `--option=val1,val2,val3` is three values for the `--option` argument. If you wish to
-    /// change the delimiter to another character you can use [`Arg::value_delimiter(char)`],
-    /// alternatively you can turn delimiting values **OFF** by using
-    /// [`Arg::use_delimiter(false)`][Arg::use_delimiter]
+    /// **NOTE:** If you wish for this argument to only be required unless *any of* these args are
+    /// present see [`Arg::required_unless_present_any`]
     ///
     /// # Examples
     ///
     /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("mode")
-    ///         .long("mode")
-    ///         .takes_value(true))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--mode", "fast"
-    ///     ]);
-    ///
-    /// assert!(m.is_present("mode"));
-    /// assert_eq!(m.value_of("mode"), Some("fast"));
+    /// # use clap::Arg;
+    /// Arg::new("config")
+    ///     .required_unless_present_all(&["cfg", "dbg"])
+    /// # ;
     /// ```
-    /// [`Arg::value_delimiter(char)`]: Arg::value_delimiter()
-    /// [multiple values]: Arg::multiple_values
-    #[inline]
-    pub fn takes_value(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::TakesValue)
-        } else {
-            self.unset_setting(ArgSettings::TakesValue)
-        }
-    }
-
-    /// Allows values which start with a leading hyphen (`-`)
     ///
-    /// **NOTE:** Setting this requires [`Arg::takes_value`]
-    ///
-    /// **WARNING**: Take caution when using this setting combined with
-    /// [`Arg::multiple_values`], as this becomes ambiguous `$ prog --arg -- -- val`. All
-    /// three `--, --, val` will be values when the user may have thought the second `--` would
-    /// constitute the normal, "Only positional args follow" idiom. To fix this, consider using
-    /// [`Arg::multiple_occurrences`] which only allows a single value at a time.
-    ///
-    /// **WARNING**: When building your CLIs, consider the effects of allowing leading hyphens and
-    /// the user passing in a value that matches a valid short. For example, `prog -opt -F` where
-    /// `-F` is supposed to be a value, yet `-F` is *also* a valid short for another arg.
-    /// Care should be taken when designing these args. This is compounded by the ability to "stack"
-    /// short args. I.e. if `-val` is supposed to be a value, but `-v`, `-a`, and `-l` are all valid
-    /// shorts.
-    ///
-    /// # Examples
+    /// In the following example, the required argument is *not* provided, but it's not an error
+    /// because *all* of the `names` args have been supplied.
     ///
     /// ```rust
     /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("pat")
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .required_unless_present_all(&["dbg", "infile"])
     ///         .takes_value(true)
-    ///         .allow_hyphen_values(true)
-    ///         .long("pattern"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--pattern", "-file"
+    ///         .long("config"))
+    ///     .arg(Arg::new("dbg")
+    ///         .long("debug"))
+    ///     .arg(Arg::new("infile")
+    ///         .short('i')
+    ///         .takes_value(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--debug", "-i", "file"
     ///     ]);
     ///
-    /// assert_eq!(m.value_of("pat"), Some("-file"));
+    /// assert!(res.is_ok());
     /// ```
     ///
-    /// Not setting `Arg::allow_hyphen_values(true)` and supplying a value which starts with a
-    /// hyphen is an error.
+    /// Setting [`Arg::required_unless_present_all(names)`] and *not* supplying
+    /// either *all* of `unless` args or the `self` arg is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
-    ///     .arg(Arg::new("pat")
+    ///     .arg(Arg::new("cfg")
+    ///         .required_unless_present_all(&["dbg", "infile"])
     ///         .takes_value(true)
-    ///         .long("pattern"))
+    ///         .long("config"))
+    ///     .arg(Arg::new("dbg")
+    ///         .long("debug"))
+    ///     .arg(Arg::new("infile")
+    ///         .short('i')
+    ///         .takes_value(true))
     ///     .try_get_matches_from(vec![
-    ///         "prog", "--pattern", "-file"
+    ///         "prog"
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
     /// ```
-    /// [`Arg::number_of_values(1)`]: Arg::number_of_values()
-    #[inline]
-    pub fn allow_hyphen_values(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::AllowHyphenValues)
-        } else {
-            self.unset_setting(ArgSettings::AllowHyphenValues)
-        }
+    /// [required]: Arg::required()
+    /// [`Arg::required_unless_present_any`]: Arg::required_unless_present_any()
+    /// [`Arg::required_unless_present_all(names)`]: Arg::required_unless_present_all()
+    pub fn required_unless_present_all<T, I>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Key,
+    {
+        self.r_unless_all.extend(names.into_iter().map(Id::from));
+        self
     }
 
-    /// Requires that options use the `--option=val` syntax
+    /// Sets this arg as [required] unless *any* of the specified arguments are present at runtime.
     ///
-    /// i.e. an equals between the option and associated value.
+    /// In other words, parsing will succeed only if user either
+    /// * supplies the `self` arg.
+    /// * supplies *one or more* of the `unless` arguments.
     ///
-    /// **NOTE:** Setting this requires [`Arg::takes_value`]
+    /// **NOTE:** If you wish for this argument to be required unless *all of* these args are
+    /// present see [`Arg::required_unless_present_all`]
     ///
     /// # Examples
     ///
-    /// Setting `require_equals` requires that the option have an equals sign between
-    /// it and the associated value.
+    /// ```rust
+    /// # use clap::Arg;
+    /// Arg::new("config")
+    ///     .required_unless_present_any(&["cfg", "dbg"])
+    /// # ;
+    /// ```
+    ///
+    /// Setting [`Arg::required_unless_present_any(names)`] requires that the argument be used at runtime
+    /// *unless* *at least one of* the args in `names` are present. In the following example, the
+    /// required argument is *not* provided, but it's not an error because one the `unless` args
+    /// have been supplied.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .required_unless_present_any(&["dbg", "infile"])
+    ///         .takes_value(true)
+    ///         .long("config"))
+    ///     .arg(Arg::new("dbg")
+    ///         .long("debug"))
+    ///     .arg(Arg::new("infile")
+    ///         .short('i')
+    ///         .takes_value(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--debug"
+    ///     ]);
+    ///
+    /// assert!(res.is_ok());
+    /// ```
+    ///
+    /// Setting [`Arg::required_unless_present_any(names)`] and *not* supplying *at least one of* `names`
+    /// or this arg is an error.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .required_unless_present_any(&["dbg", "infile"])
+    ///         .takes_value(true)
+    ///         .long("config"))
+    ///     .arg(Arg::new("dbg")
+    ///         .long("debug"))
+    ///     .arg(Arg::new("infile")
+    ///         .short('i')
+    ///         .takes_value(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// ```
+    /// [required]: Arg::required()
+    /// [`Arg::required_unless_present_any(names)`]: Arg::required_unless_present_any()
+    /// [`Arg::required_unless_present_all`]: Arg::required_unless_present_all()
+    pub fn required_unless_present_any<T, I>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Key,
+    {
+        self.r_unless.extend(names.into_iter().map(Id::from));
+        self
+    }
+
+    /// This argument is [required] only if the specified `arg` is present at runtime and its value
+    /// equals `val`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Arg;
+    /// Arg::new("config")
+    ///     .required_if_eq("other_arg", "value")
+    /// # ;
+    /// ```
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .takes_value(true)
+    ///         .required_if_eq("other", "special")
+    ///         .long("config"))
+    ///     .arg(Arg::new("other")
+    ///         .long("other")
+    ///         .takes_value(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--other", "not-special"
+    ///     ]);
+    ///
+    /// assert!(res.is_ok()); // We didn't use --other=special, so "cfg" wasn't required
+    ///
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .takes_value(true)
+    ///         .required_if_eq("other", "special")
+    ///         .long("config"))
+    ///     .arg(Arg::new("other")
+    ///         .long("other")
+    ///         .takes_value(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--other", "special"
+    ///     ]);
+    ///
+    /// // We did use --other=special so "cfg" had become required but was missing.
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    ///
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .takes_value(true)
+    ///         .required_if_eq("other", "special")
+    ///         .long("config"))
+    ///     .arg(Arg::new("other")
+    ///         .long("other")
+    ///         .takes_value(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--other", "SPECIAL"
+    ///     ]);
+    ///
+    /// // By default, the comparison is case-sensitive, so "cfg" wasn't required
+    /// assert!(res.is_ok());
+    ///
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .takes_value(true)
+    ///         .required_if_eq("other", "special")
+    ///         .long("config"))
+    ///     .arg(Arg::new("other")
+    ///         .long("other")
+    ///         .ignore_case(true)
+    ///         .takes_value(true))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--other", "SPECIAL"
+    ///     ]);
+    ///
+    /// // However, case-insensitive comparisons can be enabled.  This typically occurs when using Arg::possible_values().
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// ```
+    /// [`Arg::requires(name)`]: Arg::requires()
+    /// [Conflicting]: Arg::conflicts_with()
+    /// [required]: Arg::required()
+    pub fn required_if_eq<T: Key>(mut self, arg_id: T, val: &'help str) -> Self {
+        self.r_ifs.push((arg_id.into(), val));
+        self
+    }
+
+    /// Specify this argument is [required] based on multiple conditions.
+    ///
+    /// The conditions are set up in a `(arg, val)` style tuple. The requirement will only become
+    /// valid if one of the specified `arg`'s value equals its corresponding `val`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Arg;
+    /// Arg::new("config")
+    ///     .required_if_eq_any(&[
+    ///         ("extra", "val"),
+    ///         ("option", "spec")
+    ///     ])
+    /// # ;
+    /// ```
+    ///
+    /// Setting `Arg::required_if_eq_any(&[(arg, val)])` makes this arg required if any of the `arg`s
+    /// are used at runtime and it's corresponding value is equal to `val`. If the `arg`'s value is
+    /// anything other than `val`, this argument isn't required.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .required_if_eq_any(&[
+    ///             ("extra", "val"),
+    ///             ("option", "spec")
+    ///         ])
+    ///         .takes_value(true)
+    ///         .long("config"))
+    ///     .arg(Arg::new("extra")
+    ///         .takes_value(true)
+    ///         .long("extra"))
+    ///     .arg(Arg::new("option")
+    ///         .takes_value(true)
+    ///         .long("option"))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--option", "other"
+    ///     ]);
+    ///
+    /// assert!(res.is_ok()); // We didn't use --option=spec, or --extra=val so "cfg" isn't required
+    /// ```
+    ///
+    /// Setting `Arg::required_if_eq_any(&[(arg, val)])` and having any of the `arg`s used with its
+    /// value of `val` but *not* using this arg is an error.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .required_if_eq_any(&[
+    ///             ("extra", "val"),
+    ///             ("option", "spec")
+    ///         ])
+    ///         .takes_value(true)
+    ///         .long("config"))
+    ///     .arg(Arg::new("extra")
+    ///         .takes_value(true)
+    ///         .long("extra"))
+    ///     .arg(Arg::new("option")
+    ///         .takes_value(true)
+    ///         .long("option"))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--option", "spec"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// ```
+    /// [`Arg::requires(name)`]: Arg::requires()
+    /// [Conflicting]: Arg::conflicts_with()
+    /// [required]: Arg::required()
+    pub fn required_if_eq_any<T: Key>(mut self, ifs: &[(T, &'help str)]) -> Self {
+        self.r_ifs
+            .extend(ifs.iter().map(|(id, val)| (Id::from_ref(id), *val)));
+        self
+    }
+
+    /// Specify this argument is [required] based on multiple conditions.
+    ///
+    /// The conditions are set up in a `(arg, val)` style tuple. The requirement will only become
+    /// valid if every one of the specified `arg`'s value equals its corresponding `val`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Arg;
+    /// Arg::new("config")
+    ///     .required_if_eq_all(&[
+    ///         ("extra", "val"),
+    ///         ("option", "spec")
+    ///     ])
+    /// # ;
+    /// ```
+    ///
+    /// Setting `Arg::required_if_eq_all(&[(arg, val)])` makes this arg required if all of the `arg`s
+    /// are used at runtime and every value is equal to its corresponding `val`. If the `arg`'s value is
+    /// anything other than `val`, this argument isn't required.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .required_if_eq_all(&[
+    ///             ("extra", "val"),
+    ///             ("option", "spec")
+    ///         ])
+    ///         .takes_value(true)
+    ///         .long("config"))
+    ///     .arg(Arg::new("extra")
+    ///         .takes_value(true)
+    ///         .long("extra"))
+    ///     .arg(Arg::new("option")
+    ///         .takes_value(true)
+    ///         .long("option"))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--option", "spec"
+    ///     ]);
+    ///
+    /// assert!(res.is_ok()); // We didn't use --option=spec --extra=val so "cfg" isn't required
+    /// ```
+    ///
+    /// Setting `Arg::required_if_eq_all(&[(arg, val)])` and having all of the `arg`s used with its
+    /// value of `val` but *not* using this arg is an error.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .required_if_eq_all(&[
+    ///             ("extra", "val"),
+    ///             ("option", "spec")
+    ///         ])
+    ///         .takes_value(true)
+    ///         .long("config"))
+    ///     .arg(Arg::new("extra")
+    ///         .takes_value(true)
+    ///         .long("extra"))
+    ///     .arg(Arg::new("option")
+    ///         .takes_value(true)
+    ///         .long("option"))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--extra", "val", "--option", "spec"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// ```
+    /// [required]: Arg::required()
+    pub fn required_if_eq_all<T: Key>(mut self, ifs: &[(T, &'help str)]) -> Self {
+        self.r_ifs_all
+            .extend(ifs.iter().map(|(id, val)| (Id::from_ref(id), *val)));
+        self
+    }
+
+    /// Require another argument if this arg was present at runtime and its value equals to `val`.
+    ///
+    /// This method takes `value, another_arg` pair. At runtime, clap will check
+    /// if this arg (`self`) is present and its value equals to `val`.
+    /// If it does, `another_arg` will be marked as required.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Arg;
+    /// Arg::new("config")
+    ///     .requires_if("val", "arg")
+    /// # ;
+    /// ```
+    ///
+    /// Setting `Arg::requires_if(val, arg)` requires that the `arg` be used at runtime if the
+    /// defining argument's value is equal to `val`. If the defining argument is anything other than
+    /// `val`, the other argument isn't required.
     ///
     /// ```rust
     /// # use clap::{App, Arg};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
     ///         .takes_value(true)
-    ///         .require_equals(true)
+    ///         .requires_if("my.cfg", "other")
     ///         .long("config"))
+    ///     .arg(Arg::new("other"))
     ///     .try_get_matches_from(vec![
-    ///         "prog", "--config=file.conf"
+    ///         "prog", "--config", "some.cfg"
     ///     ]);
     ///
-    /// assert!(res.is_ok());
+    /// assert!(res.is_ok()); // We didn't use --config=my.cfg, so other wasn't required
     /// ```
     ///
-    /// Setting `require_equals` and *not* supplying the equals will cause an
+    /// Setting `Arg::requires_if(val, arg)` and setting the value to `val` but *not* supplying
+    /// `arg` is an error.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .takes_value(true)
+    ///         .requires_if("my.cfg", "input")
+    ///         .long("config"))
+    ///     .arg(Arg::new("input"))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--config", "my.cfg"
+    ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// ```
+    /// [`Arg::requires(name)`]: Arg::requires()
+    /// [Conflicting]: Arg::conflicts_with()
+    /// [override]: Arg::overrides_with()
+    pub fn requires_if<T: Key>(mut self, val: &'help str, arg_id: T) -> Self {
+        self.requires.push((Some(val), arg_id.into()));
+        self
+    }
+
+    /// Allows multiple conditional requirements.
+    ///
+    /// The requirement will only become valid if this arg's value equals `val`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Arg;
+    /// Arg::new("config")
+    ///     .requires_ifs(&[
+    ///         ("val", "arg"),
+    ///         ("other_val", "arg2"),
+    ///     ])
+    /// # ;
+    /// ```
+    ///
+    /// Setting `Arg::requires_ifs(&["val", "arg"])` requires that the `arg` be used at runtime if the
+    /// defining argument's value is equal to `val`. If the defining argument's value is anything other
+    /// than `val`, `arg` isn't required.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .takes_value(true)
+    ///         .requires_ifs(&[
+    ///             ("special.conf", "opt"),
+    ///             ("other.conf", "other"),
+    ///         ])
+    ///         .long("config"))
+    ///     .arg(Arg::new("opt")
+    ///         .long("option")
+    ///         .takes_value(true))
+    ///     .arg(Arg::new("other"))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--config", "special.conf"
+    ///     ]);
+    ///
+    /// assert!(res.is_err()); // We  used --config=special.conf so --option <val> is required
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// ```
+    /// [`Arg::requires(name)`]: Arg::requires()
+    /// [Conflicting]: Arg::conflicts_with()
+    /// [override]: Arg::overrides_with()
+    pub fn requires_ifs<T: Key>(mut self, ifs: &[(&'help str, T)]) -> Self {
+        self.requires
+            .extend(ifs.iter().map(|(val, arg)| (Some(*val), Id::from(arg))));
+        self
+    }
+
+    /// Require these arguments names when this one is presen
+    ///
+    /// i.e. when using this argument, the following arguments *must* be present.
+    ///
+    /// **NOTE:** [Conflicting] rules and [override] rules take precedence over being required
+    /// by default.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Arg;
+    /// Arg::new("config")
+    ///     .requires_all(&["input", "output"])
+    /// # ;
+    /// ```
+    ///
+    /// Setting `Arg::requires_all(&[arg, arg2])` requires that all the arguments be used at
+    /// runtime if the defining argument is used. If the defining argument isn't used, the other
+    /// argument isn't required
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let res = App::new("prog")
+    ///     .arg(Arg::new("cfg")
+    ///         .takes_value(true)
+    ///         .requires("input")
+    ///         .long("config"))
+    ///     .arg(Arg::new("input")
+    ///         .index(1))
+    ///     .arg(Arg::new("output")
+    ///         .index(2))
+    ///     .try_get_matches_from(vec![
+    ///         "prog"
+    ///     ]);
+    ///
+    /// assert!(res.is_ok()); // We didn't use cfg, so input and output weren't required
+    /// ```
+    ///
+    /// Setting `Arg::requires_all(&[arg, arg2])` and *not* supplying all the arguments is an
     /// error.
     ///
     /// ```rust
@@ -3675,252 +4126,595 @@ impl<'help> Arg<'help> {
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
     ///         .takes_value(true)
-    ///         .require_equals(true)
+    ///         .requires_all(&["input", "output"])
     ///         .long("config"))
+    ///     .arg(Arg::new("input")
+    ///         .index(1))
+    ///     .arg(Arg::new("output")
+    ///         .index(2))
     ///     .try_get_matches_from(vec![
-    ///         "prog", "--config", "file.conf"
+    ///         "prog", "--config", "file.conf", "in.txt"
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::NoEquals);
+    /// // We didn't use output
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
     /// ```
-    #[inline]
-    pub fn require_equals(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::RequireEquals)
-        } else {
-            self.unset_setting(ArgSettings::RequireEquals)
-        }
+    /// [Conflicting]: Arg::conflicts_with()
+    /// [override]: Arg::overrides_with()
+    pub fn requires_all<T: Key>(mut self, names: &[T]) -> Self {
+        self.requires.extend(names.iter().map(|s| (None, s.into())));
+        self
     }
 
-    /// Specifies that an argument can be matched to all child [`Subcommand`]s.
+    /// This argument is mutually exclusive with the specified argument.
     ///
-    /// **NOTE:** Global arguments *only* propagate down, **not** up (to parent commands), however
-    /// their values once a user uses them will be propagated back up to parents. In effect, this
-    /// means one should *define* all global arguments at the top level, however it doesn't matter
-    /// where the user *uses* the global argument.
+    /// **NOTE:** Conflicting rules take precedence over being required by default. Conflict rules
+    /// only need to be set for one of the two arguments, they do not need to be set for each.
+    ///
+    /// **NOTE:** Defining a conflict is two-way, but does *not* need to defined for both arguments
+    /// (i.e. if A conflicts with B, defining A.conflicts_with(B) is sufficient. You do not
+    /// need to also do B.conflicts_with(A))
+    ///
+    /// **NOTE:** [`Arg::conflicts_with_all(names)`] allows specifying an argument which conflicts with more than one argument.
+    ///
+    /// **NOTE** [`Arg::exclusive(true)`] allows specifying an argument which conflicts with every other argument.
     ///
     /// # Examples
     ///
-    /// Assume an application with two subcommands, and you'd like to define a
-    /// `--verbose` flag that can be called on any of the subcommands and parent, but you don't
-    /// want to clutter the source with three duplicate [`Arg`] definitions.
-    ///
     /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("verb")
-    ///         .long("verbose")
-    ///         .short('v')
-    ///         .global(true))
-    ///     .subcommand(App::new("test"))
-    ///     .subcommand(App::new("do-stuff"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "do-stuff", "--verbose"
-    ///     ]);
-    ///
-    /// assert_eq!(m.subcommand_name(), Some("do-stuff"));
-    /// let sub_m = m.subcommand_matches("do-stuff").unwrap();
-    /// assert!(sub_m.is_present("verb"));
+    /// # use clap::Arg;
+    /// Arg::new("config")
+    ///     .conflicts_with("debug")
+    /// # ;
     /// ```
     ///
-    /// [`Subcommand`]: crate::Subcommand
-    /// [`ArgMatches::is_present("flag")`]: ArgMatches::is_present()
-    #[inline]
-    pub fn global(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::Global)
-        } else {
-            self.unset_setting(ArgSettings::Global)
-        }
-    }
-
-    /// Specifies that *multiple values* may only be set using the delimiter.
-    ///
-    /// This means if an option is encountered, and no delimiter is found, it is assumed that no
-    /// additional values for that option follow. This is unlike the default, where it is generally
-    /// assumed that more values will follow regardless of whether or not a delimiter is used.
-    ///
-    /// **NOTE:** The default is `false`.
-    ///
-    /// **NOTE:** Setting this requires [`Arg::use_delimiter`] and
-    /// [`Arg::takes_value`]
-    ///
-    /// **NOTE:** It's a good idea to inform the user that use of a delimiter is required, either
-    /// through help text or other means.
-    ///
-    /// # Examples
-    ///
-    /// These examples demonstrate what happens when `require_delimiter(true)` is used. Notice
-    /// everything works in this first example, as we use a delimiter, as expected.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let delims = App::new("prog")
-    ///     .arg(Arg::new("opt")
-    ///         .short('o')
-    ///         .takes_value(true)
-    ///         .use_delimiter(true)
-    ///         .require_delimiter(true)
-    ///         .multiple_values(true))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-o", "val1,val2,val3",
-    ///     ]);
-    ///
-    /// assert!(delims.is_present("opt"));
-    /// assert_eq!(delims.values_of("opt").unwrap().collect::<Vec<_>>(), ["val1", "val2", "val3"]);
-    /// ```
-    ///
-    /// In this next example, we will *not* use a delimiter. Notice it's now an error.
+    /// Setting conflicting argument, and having both arguments present at runtime is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
-    ///     .arg(Arg::new("opt")
-    ///         .short('o')
+    ///     .arg(Arg::new("cfg")
     ///         .takes_value(true)
-    ///         .use_delimiter(true)
-    ///         .require_delimiter(true))
+    ///         .conflicts_with("debug")
+    ///         .long("config"))
+    ///     .arg(Arg::new("debug")
+    ///         .long("debug"))
     ///     .try_get_matches_from(vec![
-    ///         "prog", "-o", "val1", "val2", "val3",
+    ///         "prog", "--debug", "--config", "file.conf"
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// let err = res.unwrap_err();
-    /// assert_eq!(err.kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
     /// ```
     ///
-    /// What's happening is `-o` is getting `val1`, and because delimiters are required yet none
-    /// were present, it stops parsing `-o`. At this point it reaches `val2` and because no
-    /// positional arguments have been defined, it's an error of an unexpected argument.
-    ///
-    /// In this final example, we contrast the above with `clap`'s default behavior where the above
-    /// is *not* an error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let delims = App::new("prog")
-    ///     .arg(Arg::new("opt")
-    ///         .short('o')
-    ///         .takes_value(true)
-    ///         .multiple_values(true))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-o", "val1", "val2", "val3",
-    ///     ]);
-    ///
-    /// assert!(delims.is_present("opt"));
-    /// assert_eq!(delims.values_of("opt").unwrap().collect::<Vec<_>>(), ["val1", "val2", "val3"]);
-    /// ```
-    #[inline]
-    pub fn require_delimiter(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::RequireDelimiter)
-        } else {
-            self.unset_setting(ArgSettings::RequireDelimiter)
-        }
+    /// [`Arg::conflicts_with_all(names)`]: Arg::conflicts_with_all()
+    /// [`Arg::exclusive(true)`]: Arg::exclusive()
+    pub fn conflicts_with<T: Key>(mut self, arg_id: T) -> Self {
+        self.blacklist.push(arg_id.into());
+        self
     }
 
-    /// Do not display the [possible values][Arg::possible_values] in the help message.
+    /// This argument is mutually exclusive with the specified arguments.
     ///
-    /// This is useful for args with many values, or ones which are explained elsewhere in the
-    /// help text.
+    /// See [`Arg::conflicts_with`].
     ///
-    /// **NOTE:** Setting this requires [`Arg::takes_value`]
+    /// **NOTE:** Conflicting rules take precedence over being required by default. Conflict rules
+    /// only need to be set for one of the two arguments, they do not need to be set for each.
     ///
-    /// To set this for all arguments, see
-    /// [`AppSettings::HidePossibleValues`][crate::AppSettings::HidePossibleValues].
+    /// **NOTE:** Defining a conflict is two-way, but does *not* need to defined for both arguments
+    /// (i.e. if A conflicts with B, defining A.conflicts_with(B) is sufficient. You do not need
+    /// need to also do B.conflicts_with(A))
+    ///
+    /// **NOTE:** [`Arg::exclusive(true)`] allows specifying an argument which conflicts with every other argument.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("mode")
-    ///         .long("mode")
-    ///         .possible_values(["fast", "slow"])
-    ///         .takes_value(true)
-    ///         .hide_possible_values(true));
-    /// ```
-    /// If we were to run the above program with `--help` the `[values: fast, slow]` portion of
-    /// the help text would be omitted.
-    #[inline]
-    pub fn hide_possible_values(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::HidePossibleValues)
-        } else {
-            self.unset_setting(ArgSettings::HidePossibleValues)
-        }
-    }
-
-    /// Do not display the default value of the argument in the help message.
-    ///
-    /// This is useful when default behavior of an arg is explained elsewhere in the help text.
-    ///
-    /// **NOTE:** Setting this requires [`Arg::takes_value`]
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("connect")
-    ///     .arg(Arg::new("host")
-    ///         .long("host")
-    ///         .default_value("localhost")
-    ///         .takes_value(true)
-    ///         .hide_default_value(true));
-    ///
+    /// # use clap::Arg;
+    /// Arg::new("config")
+    ///     .conflicts_with_all(&["debug", "input"])
+    /// # ;
     /// ```
     ///
-    /// If we were to run the above program with `--help` the `[default: localhost]` portion of
-    /// the help text would be omitted.
-    #[inline]
-    pub fn hide_default_value(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::HideDefaultValue)
-        } else {
-            self.unset_setting(ArgSettings::HideDefaultValue)
-        }
-    }
-
-    /// Do not display the argument in help message.
-    ///
-    /// **NOTE:** This does **not** hide the argument from usage strings on error
-    ///
-    /// # Examples
-    ///
-    /// Setting `Hidden` will hide the argument when displaying help text
+    /// Setting conflicting argument, and having any of the arguments present at runtime with a
+    /// conflicting argument is an error.
     ///
     /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
+    /// # use clap::{App, Arg, ErrorKind};
+    /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .long("config")
-    ///         .hide(true)
-    ///         .help("Some help text describing the --config arg"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--help"
+    ///         .takes_value(true)
+    ///         .conflicts_with_all(&["debug", "input"])
+    ///         .long("config"))
+    ///     .arg(Arg::new("debug")
+    ///         .long("debug"))
+    ///     .arg(Arg::new("input")
+    ///         .index(1))
+    ///     .try_get_matches_from(vec![
+    ///         "prog", "--config", "file.conf", "file.txt"
     ///     ]);
+    ///
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
+    /// ```
+    /// [`Arg::conflicts_with`]: Arg::conflicts_with()
+    /// [`Arg::exclusive(true)`]: Arg::exclusive()
+    pub fn conflicts_with_all(mut self, names: &[&str]) -> Self {
+        self.blacklist.extend(names.iter().map(Id::from));
+        self
+    }
+
+    /// Sets an overridable argument.
+    ///
+    /// i.e. this argument and the following argument
+    /// will override each other in POSIX style (whichever argument was specified at runtime
+    /// **last** "wins")
+    ///
+    /// **NOTE:** When an argument is overridden it is essentially as if it never was used, any
+    /// conflicts, requirements, etc. are evaluated **after** all "overrides" have been removed
+    ///
+    /// **WARNING:** Positional arguments and options which accept
+    /// [`Arg::multiple_occurrences`] cannot override themselves (or we
+    /// would never be able to advance to the next positional). If a positional
+    /// argument or option with one of the [`Arg::multiple_occurrences`]
+    /// settings lists itself as an override, it is simply ignored.
+    ///
+    /// # Examples
+    ///
+    /// ```rust # use clap::{App, Arg};
+    /// # use clap::{App, arg};
+    /// let m = App::new("prog")
+    ///     .arg(arg!(-f --flag "some flag")
+    ///         .conflicts_with("debug"))
+    ///     .arg(arg!(-d --debug "other flag"))
+    ///     .arg(arg!(-c --color "third flag")
+    ///         .overrides_with("flag"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "-f", "-d", "-c"]);
+    ///             //    ^~~~~~~~~~~~^~~~~ flag is overridden by color
+    ///
+    /// assert!(m.is_present("color"));
+    /// assert!(m.is_present("debug")); // even though flag conflicts with debug, it's as if flag
+    ///                                 // was never used because it was overridden with color
+    /// assert!(!m.is_present("flag"));
+    /// ```
+    /// Care must be taken when using this setting, and having an arg override with itself. This
+    /// is common practice when supporting things like shell aliases, config files, etc.
+    /// However, when combined with multiple values, it can get dicy.
+    /// Here is how clap handles such situations:
+    ///
+    /// When a flag overrides itself, it's as if the flag was only ever used once (essentially
+    /// preventing a "Unexpected multiple usage" error):
+    ///
+    /// ```rust
+    /// # use clap::{App, arg};
+    /// let m = App::new("posix")
+    ///             .arg(arg!(--flag  "some flag").overrides_with("flag"))
+    ///             .get_matches_from(vec!["posix", "--flag", "--flag"]);
+    /// assert!(m.is_present("flag"));
+    /// assert_eq!(m.occurrences_of("flag"), 1);
     /// ```
     ///
-    /// The above example displays
+    /// Making an arg [`Arg::multiple_occurrences`] and override itself
+    /// is essentially meaningless. Therefore clap ignores an override of self
+    /// if it's a flag and it already accepts multiple occurrences.
     ///
-    /// ```text
-    /// helptest
-    ///
-    /// USAGE:
-    ///    helptest [OPTIONS]
-    ///
-    /// OPTIONS:
-    /// -h, --help       Print help information
-    /// -V, --version    Print version information
     /// ```
+    /// # use clap::{App, arg};
+    /// let m = App::new("posix")
+    ///             .arg(arg!(--flag ...  "some flag").overrides_with("flag"))
+    ///             .get_matches_from(vec!["", "--flag", "--flag", "--flag", "--flag"]);
+    /// assert!(m.is_present("flag"));
+    /// assert_eq!(m.occurrences_of("flag"), 4);
+    /// ```
+    ///
+    /// Now notice with options (which *do not* set
+    /// [`Arg::multiple_occurrences`]), it's as if only the last
+    /// occurrence happened.
+    ///
+    /// ```
+    /// # use clap::{App, arg};
+    /// let m = App::new("posix")
+    ///             .arg(arg!(--opt <val> "some option").overrides_with("opt"))
+    ///             .get_matches_from(vec!["", "--opt=some", "--opt=other"]);
+    /// assert!(m.is_present("opt"));
+    /// assert_eq!(m.occurrences_of("opt"), 1);
+    /// assert_eq!(m.value_of("opt"), Some("other"));
+    /// ```
+    ///
+    /// This will also work when [`Arg::multiple_values`] is enabled:
+    ///
+    /// ```
+    /// # use clap::{App, Arg};
+    /// let m = App::new("posix")
+    ///             .arg(
+    ///                 Arg::new("opt")
+    ///                     .long("opt")
+    ///                     .takes_value(true)
+    ///                     .multiple_values(true)
+    ///                     .overrides_with("opt")
+    ///             )
+    ///             .get_matches_from(vec!["", "--opt", "1", "2", "--opt", "3", "4", "5"]);
+    /// assert!(m.is_present("opt"));
+    /// assert_eq!(m.occurrences_of("opt"), 1);
+    /// assert_eq!(m.values_of("opt").unwrap().collect::<Vec<_>>(), &["3", "4", "5"]);
+    /// ```
+    ///
+    /// Just like flags, options with [`Arg::multiple_occurrences`] set
+    /// will ignore the "override self" setting.
+    ///
+    /// ```
+    /// # use clap::{App, arg};
+    /// let m = App::new("posix")
+    ///             .arg(arg!(--opt <val> ... "some option")
+    ///                 .multiple_values(true)
+    ///                 .overrides_with("opt"))
+    ///             .get_matches_from(vec!["", "--opt", "first", "over", "--opt", "other", "val"]);
+    /// assert!(m.is_present("opt"));
+    /// assert_eq!(m.occurrences_of("opt"), 2);
+    /// assert_eq!(m.values_of("opt").unwrap().collect::<Vec<_>>(), &["first", "over", "other", "val"]);
+    /// ```
+    pub fn overrides_with<T: Key>(mut self, arg_id: T) -> Self {
+        self.overrides.push(arg_id.into());
+        self
+    }
+
+    /// Sets multiple mutually overridable arguments by name.
+    ///
+    /// i.e. this argument and the following argument will override each other in POSIX style
+    /// (whichever argument was specified at runtime **last** "wins")
+    ///
+    /// **NOTE:** When an argument is overridden it is essentially as if it never was used, any
+    /// conflicts, requirements, etc. are evaluated **after** all "overrides" have been removed
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, arg};
+    /// let m = App::new("prog")
+    ///     .arg(arg!(-f --flag "some flag")
+    ///         .conflicts_with("color"))
+    ///     .arg(arg!(-d --debug "other flag"))
+    ///     .arg(arg!(-c --color "third flag")
+    ///         .overrides_with_all(&["flag", "debug"]))
+    ///     .get_matches_from(vec![
+    ///         "prog", "-f", "-d", "-c"]);
+    ///             //    ^~~~~~^~~~~~~~~ flag and debug are overridden by color
+    ///
+    /// assert!(m.is_present("color")); // even though flag conflicts with color, it's as if flag
+    ///                                 // and debug were never used because they were overridden
+    ///                                 // with color
+    /// assert!(!m.is_present("debug"));
+    /// assert!(!m.is_present("flag"));
+    /// ```
+    pub fn overrides_with_all<T: Key>(mut self, names: &[T]) -> Self {
+        self.overrides.extend(names.iter().map(Id::from));
+        self
+    }
+}
+
+/// Reflection
+impl<'help> Arg<'help> {
+    /// Get the name of the argument
     #[inline]
-    pub fn hide(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::Hidden)
+    pub fn get_name(&self) -> &'help str {
+        self.name
+    }
+
+    /// Get the help specified for this argument, if any
+    #[inline]
+    pub fn get_help(&self) -> Option<&'help str> {
+        self.help
+    }
+
+    /// Get the long help specified for this argument, if any
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Arg;
+    /// let arg = Arg::new("foo").long_help("long help");
+    /// assert_eq!(Some("long help"), arg.get_long_help());
+    /// ```
+    ///
+    #[inline]
+    pub fn get_long_help(&self) -> Option<&'help str> {
+        self.long_help
+    }
+
+    /// Get the help heading specified for this argument, if any
+    #[inline]
+    pub fn get_help_heading(&self) -> Option<&'help str> {
+        self.help_heading.unwrap_or_default()
+    }
+
+    /// Get the short option name for this argument, if any
+    #[inline]
+    pub fn get_short(&self) -> Option<char> {
+        self.short
+    }
+
+    /// Get visible short aliases for this argument, if any
+    #[inline]
+    pub fn get_visible_short_aliases(&self) -> Option<Vec<char>> {
+        if self.short_aliases.is_empty() {
+            None
         } else {
-            self.unset_setting(ArgSettings::Hidden)
+            Some(
+                self.short_aliases
+                    .iter()
+                    .filter_map(|(c, v)| if *v { Some(c) } else { None })
+                    .copied()
+                    .collect(),
+            )
         }
+    }
+
+    /// Get the short option name and its visible aliases, if any
+    #[inline]
+    pub fn get_short_and_visible_aliases(&self) -> Option<Vec<char>> {
+        let mut shorts = match self.short {
+            Some(short) => vec![short],
+            None => return None,
+        };
+        if let Some(aliases) = self.get_visible_short_aliases() {
+            shorts.extend(aliases);
+        }
+        Some(shorts)
+    }
+
+    /// Get the long option name for this argument, if any
+    #[inline]
+    pub fn get_long(&self) -> Option<&'help str> {
+        self.long
+    }
+
+    /// Get visible aliases for this argument, if any
+    #[inline]
+    pub fn get_visible_aliases(&self) -> Option<Vec<&'help str>> {
+        if self.aliases.is_empty() {
+            None
+        } else {
+            Some(
+                self.aliases
+                    .iter()
+                    .filter_map(|(s, v)| if *v { Some(s) } else { None })
+                    .copied()
+                    .collect(),
+            )
+        }
+    }
+
+    /// Get the long option name and its visible aliases, if any
+    #[inline]
+    pub fn get_long_and_visible_aliases(&self) -> Option<Vec<&'help str>> {
+        let mut longs = match self.long {
+            Some(long) => vec![long],
+            None => return None,
+        };
+        if let Some(aliases) = self.get_visible_aliases() {
+            longs.extend(aliases);
+        }
+        Some(longs)
+    }
+
+    /// Get the list of the possible values for this argument, if any
+    #[inline]
+    pub fn get_possible_values(&self) -> Option<&[PossibleValue]> {
+        if self.possible_vals.is_empty() {
+            None
+        } else {
+            Some(&self.possible_vals)
+        }
+    }
+
+    /// Get the names of values for this argument.
+    #[inline]
+    pub fn get_value_names(&self) -> Option<&[&'help str]> {
+        if self.val_names.is_empty() {
+            None
+        } else {
+            Some(&self.val_names)
+        }
+    }
+
+    /// Get the number of values for this argument.
+    #[inline]
+    pub fn get_num_vals(&self) -> Option<usize> {
+        self.num_vals
+    }
+
+    /// Get the index of this argument, if any
+    #[inline]
+    pub fn get_index(&self) -> Option<usize> {
+        self.index
+    }
+
+    /// Get the value hint of this argument
+    pub fn get_value_hint(&self) -> ValueHint {
+        self.value_hint
+    }
+
+    /// Get information on if this argument is global or not
+    pub fn get_global(&self) -> bool {
+        self.is_set(ArgSettings::Global)
+    }
+
+    /// Get the environment variable name specified for this argument, if any
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use std::ffi::OsStr;
+    /// # use clap::Arg;
+    /// let arg = Arg::new("foo").env("ENVIRONMENT");
+    /// assert_eq!(Some(OsStr::new("ENVIRONMENT")), arg.get_env());
+    /// ```
+    #[cfg(feature = "env")]
+    pub fn get_env(&self) -> Option<&OsStr> {
+        self.env.as_ref().map(|x| x.0)
+    }
+
+    /// Get the default values specified for this argument, if any
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Arg;
+    /// let arg = Arg::new("foo").default_value("default value");
+    /// assert_eq!(&["default value"], arg.get_default_values());
+    /// ```
+    pub fn get_default_values(&self) -> &[&OsStr] {
+        &self.default_vals
+    }
+
+    /// Checks whether this argument is a positional or not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use clap::Arg;
+    /// let arg = Arg::new("foo");
+    /// assert_eq!(true, arg.is_positional());
+    ///
+    /// let arg = Arg::new("foo").long("foo");
+    /// assert_eq!(false, arg.is_positional());
+    /// ```
+    pub fn is_positional(&self) -> bool {
+        self.long.is_none() && self.short.is_none()
+    }
+}
+
+/// Deprecated
+impl<'help> Arg<'help> {
+    /// Deprecated, replaced with [`Arg::new`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `Arg::new`")]
+    pub fn with_name<S: Into<&'help str>>(n: S) -> Self {
+        Self::new(n)
+    }
+
+    /// Deprecated in [Issue #9](https://github.com/epage/clapng/issues/9), maybe [`clap::Parser`][crate::Parser] would fit your use case?
+    #[cfg(feature = "yaml")]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Maybe clap::Parser would fit your use case? (Issue #9)"
+    )]
+    pub fn from_yaml(y: &'help Yaml) -> Self {
+        #![allow(deprecated)]
+        let yaml_file_hash = y.as_hash().expect("YAML file must be a hash");
+        // We WANT this to panic on error...so expect() is good.
+        let (name_yaml, yaml) = yaml_file_hash
+            .iter()
+            .next()
+            .expect("There must be one arg in the YAML file");
+        let name_str = name_yaml.as_str().expect("Arg name must be a string");
+        let mut a = Arg::new(name_str);
+
+        for (k, v) in yaml.as_hash().expect("Arg must be a hash") {
+            a = match k.as_str().expect("Arg fields must be strings") {
+                "short" => yaml_to_char!(a, v, short),
+                "long" => yaml_to_str!(a, v, long),
+                "aliases" => yaml_vec_or_str!(a, v, alias),
+                "help" => yaml_to_str!(a, v, help),
+                "long_help" => yaml_to_str!(a, v, long_help),
+                "required" => yaml_to_bool!(a, v, required),
+                "required_if" => yaml_tuple2!(a, v, required_if_eq),
+                "required_ifs" => yaml_tuple2!(a, v, required_if_eq),
+                "takes_value" => yaml_to_bool!(a, v, takes_value),
+                "index" => yaml_to_usize!(a, v, index),
+                "global" => yaml_to_bool!(a, v, global),
+                "multiple" => yaml_to_bool!(a, v, multiple),
+                "hidden" => yaml_to_bool!(a, v, hide),
+                "next_line_help" => yaml_to_bool!(a, v, next_line_help),
+                "group" => yaml_to_str!(a, v, group),
+                "number_of_values" => yaml_to_usize!(a, v, number_of_values),
+                "max_values" => yaml_to_usize!(a, v, max_values),
+                "min_values" => yaml_to_usize!(a, v, min_values),
+                "value_name" => yaml_to_str!(a, v, value_name),
+                "use_delimiter" => yaml_to_bool!(a, v, use_delimiter),
+                "allow_hyphen_values" => yaml_to_bool!(a, v, allow_hyphen_values),
+                "last" => yaml_to_bool!(a, v, last),
+                "require_delimiter" => yaml_to_bool!(a, v, require_delimiter),
+                "value_delimiter" => yaml_to_char!(a, v, value_delimiter),
+                "required_unless" => yaml_to_str!(a, v, required_unless_present),
+                "display_order" => yaml_to_usize!(a, v, display_order),
+                "default_value" => yaml_to_str!(a, v, default_value),
+                "default_value_if" => yaml_tuple3!(a, v, default_value_if),
+                "default_value_ifs" => yaml_tuple3!(a, v, default_value_if),
+                #[cfg(feature = "env")]
+                "env" => yaml_to_str!(a, v, env),
+                "value_names" => yaml_vec_or_str!(a, v, value_name),
+                "groups" => yaml_vec_or_str!(a, v, group),
+                "requires" => yaml_vec_or_str!(a, v, requires),
+                "requires_if" => yaml_tuple2!(a, v, requires_if),
+                "requires_ifs" => yaml_tuple2!(a, v, requires_if),
+                "conflicts_with" => yaml_vec_or_str!(a, v, conflicts_with),
+                "overrides_with" => yaml_to_str!(a, v, overrides_with),
+                "possible_values" => yaml_vec_or_str!(a, v, possible_value),
+                "case_insensitive" => yaml_to_bool!(a, v, ignore_case),
+                "required_unless_one" => yaml_vec!(a, v, required_unless_present_any),
+                "required_unless_all" => yaml_vec!(a, v, required_unless_present_all),
+                s => {
+                    panic!(
+                        "Unknown setting '{}' in YAML file for arg '{}'",
+                        s, name_str
+                    )
+                }
+            }
+        }
+
+        a
+    }
+
+    /// Deprecated in [Issue #8](https://github.com/epage/clapng/issues/8), see [`arg!`][crate::arg!].
+    #[deprecated(since = "3.0.0", note = "Replaced with `arg!`")]
+    pub fn from_usage(u: &'help str) -> Self {
+        UsageParser::from_usage(u).parse()
+    }
+
+    /// Deprecated, replaced with [`Arg::required_unless_present`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `Arg::required_unless_present`")]
+    pub fn required_unless<T: Key>(self, arg_id: T) -> Self {
+        self.required_unless_present(arg_id)
+    }
+
+    /// Deprecated, replaced with [`Arg::required_unless_present_all`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Replaced with `Arg::required_unless_present_all`"
+    )]
+    pub fn required_unless_all<T, I>(self, names: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Key,
+    {
+        self.required_unless_present_all(names)
+    }
+
+    /// Deprecated, replaced with [`Arg::required_unless_present_any`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Replaced with `Arg::required_unless_present_any`"
+    )]
+    pub fn required_unless_one<T, I>(self, names: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Key,
+    {
+        self.required_unless_present_any(names)
+    }
+
+    /// Deprecated, replaced with [`Arg::required_if_eq`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `Arg::required_if_eq`")]
+    pub fn required_if<T: Key>(self, arg_id: T, val: &'help str) -> Self {
+        self.required_if_eq(arg_id, val)
+    }
+
+    /// Deprecated, replaced with [`Arg::required_if_eq_any`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `Arg::required_if_eq_any`")]
+    pub fn required_ifs<T: Key>(self, ifs: &[(T, &'help str)]) -> Self {
+        self.required_if_eq_any(ifs)
     }
 
     /// Deprecated, replaced with [`Arg::hide`]
@@ -3930,63 +4724,6 @@ impl<'help> Arg<'help> {
         self.hide(yes)
     }
 
-    /// Match values against [`Arg::possible_values`] without matching case.
-    ///
-    /// When other arguments are conditionally required based on the
-    /// value of a case-insensitive argument, the equality check done
-    /// by [`Arg::required_if_eq`], [`Arg::required_if_eq_any`], or
-    /// [`Arg::required_if_eq_all`] is case-insensitive.
-    ///
-    ///
-    /// **NOTE:** Setting this requires [`Arg::takes_value`]
-    ///
-    /// **NOTE:** To do unicode case folding, enable the `unicode` feature flag.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("pv")
-    ///     .arg(Arg::new("option")
-    ///         .long("--option")
-    ///         .takes_value(true)
-    ///         .ignore_case(true)
-    ///         .possible_value("test123"))
-    ///     .get_matches_from(vec![
-    ///         "pv", "--option", "TeSt123",
-    ///     ]);
-    ///
-    /// assert!(m.value_of("option").unwrap().eq_ignore_ascii_case("test123"));
-    /// ```
-    ///
-    /// This setting also works when multiple values can be defined:
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("pv")
-    ///     .arg(Arg::new("option")
-    ///         .short('o')
-    ///         .long("--option")
-    ///         .takes_value(true)
-    ///         .ignore_case(true)
-    ///         .multiple_values(true)
-    ///         .possible_values(&["test123", "test321"]))
-    ///     .get_matches_from(vec![
-    ///         "pv", "--option", "TeSt123", "teST123", "tESt321"
-    ///     ]);
-    ///
-    /// let matched_vals = m.values_of("option").unwrap().collect::<Vec<_>>();
-    /// assert_eq!(&*matched_vals, &["TeSt123", "teST123", "tESt321"]);
-    /// ```
-    #[inline]
-    pub fn ignore_case(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::IgnoreCase)
-        } else {
-            self.unset_setting(ArgSettings::IgnoreCase)
-        }
-    }
-
     /// Deprecated, replaced with [`Arg::ignore_case`]
     #[deprecated(since = "3.0.0", note = "Replaced with `Arg::ignore_case`")]
     #[inline]
@@ -3994,464 +4731,10 @@ impl<'help> Arg<'help> {
         self.ignore_case(yes)
     }
 
-    /// Specifies that an argument should allow grouping of multiple values via a
-    /// delimiter.
-    ///
-    /// i.e. should `--option=val1,val2,val3` be parsed as three values (`val1`, `val2`,
-    /// and `val3`) or as a single value (`val1,val2,val3`). Defaults to using `,` (comma) as the
-    /// value delimiter for all arguments that accept values (options and positional arguments)
-    ///
-    /// **NOTE:** When this setting is used, it will default [`Arg::value_delimiter`]
-    /// to the comma `,`.
-    ///
-    /// **NOTE:** Implicitly sets [`Arg::takes_value`]
-    ///
-    /// # Examples
-    ///
-    /// The following example shows the default behavior.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let delims = App::new("prog")
-    ///     .arg(Arg::new("option")
-    ///         .long("option")
-    ///         .use_delimiter(true)
-    ///         .takes_value(true))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--option=val1,val2,val3",
-    ///     ]);
-    ///
-    /// assert!(delims.is_present("option"));
-    /// assert_eq!(delims.occurrences_of("option"), 1);
-    /// assert_eq!(delims.values_of("option").unwrap().collect::<Vec<_>>(), ["val1", "val2", "val3"]);
-    /// ```
-    /// The next example shows the difference when turning delimiters off. This is the default
-    /// behavior
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let nodelims = App::new("prog")
-    ///     .arg(Arg::new("option")
-    ///         .long("option")
-    ///         .takes_value(true))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--option=val1,val2,val3",
-    ///     ]);
-    ///
-    /// assert!(nodelims.is_present("option"));
-    /// assert_eq!(nodelims.occurrences_of("option"), 1);
-    /// assert_eq!(nodelims.value_of("option").unwrap(), "val1,val2,val3");
-    /// ```
-    /// [`Arg::value_delimiter`]: Arg::value_delimiter()
-    #[inline]
-    pub fn use_delimiter(mut self, yes: bool) -> Self {
-        if yes {
-            if self.val_delim.is_none() {
-                self.val_delim = Some(',');
-            }
-            self.takes_value(true)
-                .setting(ArgSettings::UseValueDelimiter)
-        } else {
-            self.val_delim = None;
-            self.unset_setting(ArgSettings::UseValueDelimiter)
-        }
-    }
-
-    /// Do not display in help the environment variable name.
-    ///
-    /// This is useful when the variable option is explained elsewhere in the help text.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("mode")
-    ///         .long("mode")
-    ///         .env("MODE")
-    ///         .takes_value(true)
-    ///         .hide_env(true));
-    /// ```
-    ///
-    /// If we were to run the above program with `--help` the `[env: MODE]` portion of the help
-    /// text would be omitted.
-    #[cfg(feature = "env")]
-    #[inline]
-    pub fn hide_env(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::HideEnv)
-        } else {
-            self.unset_setting(ArgSettings::HideEnv)
-        }
-    }
-
-    /// Do not display in help any values inside the associated ENV variables for the argument.
-    ///
-    /// This is useful when ENV vars contain sensitive values.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("connect")
-    ///     .arg(Arg::new("host")
-    ///         .long("host")
-    ///         .env("CONNECT")
-    ///         .takes_value(true)
-    ///         .hide_env_values(true));
-    ///
-    /// ```
-    ///
-    /// If we were to run the above program with `$ CONNECT=super_secret connect --help` the
-    /// `[default: CONNECT=super_secret]` portion of the help text would be omitted.
-    #[cfg(feature = "env")]
-    #[inline]
-    pub fn hide_env_values(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::HideEnvValues)
-        } else {
-            self.unset_setting(ArgSettings::HideEnvValues)
-        }
-    }
-
-    /// Render the [help][Arg::help] on the line after the argument.
-    ///
-    /// This can be helpful for arguments with very long or complex help messages.
-    /// This can also be helpful for arguments with very long flag names, or many/long value names.
-    ///
-    /// **NOTE:** To apply this setting to all arguments consider using
-    /// [`crate::AppSettings::NextLineHelp`]
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("opt")
-    ///         .long("long-option-flag")
-    ///         .short('o')
-    ///         .takes_value(true)
-    ///         .next_line_help(true)
-    ///         .value_names(&["value1", "value2"])
-    ///         .help("Some really long help and complex\n\
-    ///                help that makes more sense to be\n\
-    ///                on a line after the option"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--help"
-    ///     ]);
-    /// ```
-    ///
-    /// The above example displays the following help message
-    ///
-    /// ```text
-    /// nlh
-    ///
-    /// USAGE:
-    ///     nlh [OPTIONS]
-    ///
-    /// OPTIONS:
-    ///     -h, --help       Print help information
-    ///     -V, --version    Print version information
-    ///     -o, --long-option-flag <value1> <value2>
-    ///         Some really long help and complex
-    ///         help that makes more sense to be
-    ///         on a line after the option
-    /// ```
-    #[inline]
-    pub fn next_line_help(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::NextLineHelp)
-        } else {
-            self.unset_setting(ArgSettings::NextLineHelp)
-        }
-    }
-
-    /// Don't allow an argument to accept explicitly empty values.
-    ///
-    /// An empty value must be specified at the command line with an explicit `""`, `''`, or
-    /// `--option=`
-    ///
-    /// **NOTE:** By default empty values are allowed.
-    ///
-    /// **NOTE:** Setting this requires [`Arg::takes_value`].
-    ///
-    /// # Examples
-    ///
-    /// The default is allowing empty values.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .long("config")
-    ///         .short('v')
-    ///         .takes_value(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--config="
-    ///     ]);
-    ///
-    /// assert!(res.is_ok());
-    /// assert_eq!(res.unwrap().value_of("cfg"), Some(""));
-    /// ```
-    ///
-    /// By adding this setting, we can forbid empty values.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .long("config")
-    ///         .short('v')
-    ///         .takes_value(true)
-    ///         .forbid_empty_values(true))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "--config="
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::EmptyValue);
-    /// ```
-    #[inline]
-    pub fn forbid_empty_values(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::ForbidEmptyValues)
-        } else {
-            self.unset_setting(ArgSettings::ForbidEmptyValues)
-        }
-    }
-
     /// Deprecated, replaced with [`Arg::forbid_empty_values`]
     #[deprecated(since = "3.0.0", note = "Replaced with `Arg::forbid_empty_values`")]
     pub fn empty_values(self, yes: bool) -> Self {
         self.forbid_empty_values(!yes)
-    }
-
-    /// Specifies that the argument may have an unknown number of values
-    ///
-    /// Without any other settings, this argument may appear only *once*.
-    ///
-    /// For example, `--opt val1 val2` is allowed, but `--opt val1 val2 --opt val3` is not.
-    ///
-    /// **NOTE:** Setting this requires [`Arg::takes_value`].
-    ///
-    /// **WARNING:**
-    ///
-    /// Setting `multiple_values` for an argument that takes a value, but with no other details can
-    /// be dangerous in some circumstances. Because multiple values are allowed,
-    /// `--option val1 val2 val3` is perfectly valid. Be careful when designing a CLI where
-    /// positional arguments are *also* expected as `clap` will continue parsing *values* until one
-    /// of the following happens:
-    ///
-    /// - It reaches the [maximum number of values]
-    /// - It reaches a [specific number of values]
-    /// - It finds another flag or option (i.e. something that starts with a `-`)
-    /// - It reaches a [value terminator][Arg::value_terminator] is reached
-    ///
-    /// Alternatively, [require a delimiter between values][Arg::require_delimiter].
-    ///
-    /// **WARNING:**
-    ///
-    /// When using args with `multiple_values` and [`subcommands`], one needs to consider the
-    /// possibility of an argument value being the same as a valid subcommand. By default `clap` will
-    /// parse the argument in question as a value *only if* a value is possible at that moment.
-    /// Otherwise it will be parsed as a subcommand. In effect, this means using `multiple_values` with no
-    /// additional parameters and a value that coincides with a subcommand name, the subcommand
-    /// cannot be called unless another argument is passed between them.
-    ///
-    /// As an example, consider a CLI with an option `--ui-paths=<paths>...` and subcommand `signer`
-    ///
-    /// The following would be parsed as values to `--ui-paths`.
-    ///
-    /// ```text
-    /// $ program --ui-paths path1 path2 signer
-    /// ```
-    ///
-    /// This is because `--ui-paths` accepts multiple values. `clap` will continue parsing values
-    /// until another argument is reached and it knows `--ui-paths` is done parsing.
-    ///
-    /// By adding additional parameters to `--ui-paths` we can solve this issue. Consider adding
-    /// [`Arg::number_of_values(1)`] or using *only* [`Arg::multiple_occurrences`]. The following are all
-    /// valid, and `signer` is parsed as a subcommand in the first case, but a value in the second
-    /// case.
-    ///
-    /// ```text
-    /// $ program --ui-paths path1 signer
-    /// $ program --ui-paths path1 --ui-paths signer signer
-    /// ```
-    ///
-    /// # Examples
-    ///
-    /// An example with options
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("file")
-    ///         .takes_value(true)
-    ///         .multiple_values(true)
-    ///         .short('F'))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-F", "file1", "file2", "file3"
-    ///     ]);
-    ///
-    /// assert!(m.is_present("file"));
-    /// assert_eq!(m.occurrences_of("file"), 1); // notice only one occurrence
-    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
-    /// assert_eq!(files, ["file1", "file2", "file3"]);
-    /// ```
-    ///
-    /// Although `multiple_values` has been specified, we cannot use the argument more than once.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("file")
-    ///         .takes_value(true)
-    ///         .multiple_values(true)
-    ///         .short('F'))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "-F", "file1", "-F", "file2", "-F", "file3"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnexpectedMultipleUsage)
-    /// ```
-    ///
-    /// A common mistake is to define an option which allows multiple values, and a positional
-    /// argument.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("file")
-    ///         .takes_value(true)
-    ///         .multiple_values(true)
-    ///         .short('F'))
-    ///     .arg(Arg::new("word")
-    ///         .index(1))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-F", "file1", "file2", "file3", "word"
-    ///     ]);
-    ///
-    /// assert!(m.is_present("file"));
-    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
-    /// assert_eq!(files, ["file1", "file2", "file3", "word"]); // wait...what?!
-    /// assert!(!m.is_present("word")); // but we clearly used word!
-    /// ```
-    ///
-    /// The problem is `clap` doesn't know when to stop parsing values for "files". This is further
-    /// compounded by if we'd said `word -F file1 file2` it would have worked fine, so it would
-    /// appear to only fail sometimes...not good!
-    ///
-    /// A solution for the example above is to limit how many values with a [maximum], or [specific]
-    /// number, or to say [`Arg::multiple_occurrences`] is ok, but multiple values is not.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("file")
-    ///         .takes_value(true)
-    ///         .multiple_occurrences(true)
-    ///         .short('F'))
-    ///     .arg(Arg::new("word")
-    ///         .index(1))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-F", "file1", "-F", "file2", "-F", "file3", "word"
-    ///     ]);
-    ///
-    /// assert!(m.is_present("file"));
-    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
-    /// assert_eq!(files, ["file1", "file2", "file3"]);
-    /// assert!(m.is_present("word"));
-    /// assert_eq!(m.value_of("word"), Some("word"));
-    /// ```
-    ///
-    /// As a final example, let's fix the above error and get a pretty message to the user :)
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
-    /// let res = App::new("prog")
-    ///     .arg(Arg::new("file")
-    ///         .takes_value(true)
-    ///         .multiple_occurrences(true)
-    ///         .short('F'))
-    ///     .arg(Arg::new("word")
-    ///         .index(1))
-    ///     .try_get_matches_from(vec![
-    ///         "prog", "-F", "file1", "file2", "file3", "word"
-    ///     ]);
-    ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
-    /// ```
-    ///
-    /// [`subcommands`]: crate::App::subcommand()
-    /// [`Arg::number_of_values(1)`]: Arg::number_of_values()
-    /// [maximum number of values]: Arg::max_values()
-    /// [specific number of values]: Arg::number_of_values()
-    /// [maximum]: Arg::max_values()
-    /// [specific]: Arg::number_of_values()
-    #[inline]
-    pub fn multiple_values(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::MultipleValues)
-        } else {
-            self.unset_setting(ArgSettings::MultipleValues)
-        }
-    }
-
-    /// Specifies that the argument may appear more than once.
-    ///
-    /// For flags, this results in the number of occurrences of the flag being recorded. For
-    /// example `-ddd` or `-d -d -d` would count as three occurrences. For options or arguments
-    /// that take a value, this *does not* affect how many values they can accept. (i.e. only one
-    /// at a time is allowed)
-    ///
-    /// For example, `--opt val1 --opt val2` is allowed, but `--opt val1 val2` is not.
-    ///
-    /// # Examples
-    ///
-    /// An example with flags
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("verbose")
-    ///         .multiple_occurrences(true)
-    ///         .short('v'))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-v", "-v", "-v"    // note, -vvv would have same result
-    ///     ]);
-    ///
-    /// assert!(m.is_present("verbose"));
-    /// assert_eq!(m.occurrences_of("verbose"), 3);
-    /// ```
-    ///
-    /// An example with options
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("file")
-    ///         .multiple_occurrences(true)
-    ///         .takes_value(true)
-    ///         .short('F'))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-F", "file1", "-F", "file2", "-F", "file3"
-    ///     ]);
-    ///
-    /// assert!(m.is_present("file"));
-    /// assert_eq!(m.occurrences_of("file"), 3);
-    /// let files: Vec<_> = m.values_of("file").unwrap().collect();
-    /// assert_eq!(files, ["file1", "file2", "file3"]);
-    /// ```
-    #[inline]
-    pub fn multiple_occurrences(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::MultipleOccurrences)
-        } else {
-            self.unset_setting(ArgSettings::MultipleOccurrences)
-        }
     }
 
     /// Deprecated, replaced with [`Arg::multiple_occurrences`] (most likely what you want) and
@@ -4464,191 +4747,11 @@ impl<'help> Arg<'help> {
         self.multiple_occurrences(yes).multiple_values(yes)
     }
 
-    /// Consume all following arguments.
-    ///
-    /// Do not be parse them individually, but rather pass them in entirety.
-    ///
-    /// It is worth noting that setting this requires all values to come after a `--` to indicate
-    /// they should all be captured. For example:
-    ///
-    /// ```text
-    /// --foo something -- -v -v -v -b -b -b --baz -q -u -x
-    /// ```
-    ///
-    /// Will result in everything after `--` to be considered one raw argument. This behavior
-    /// may not be exactly what you are expecting and using [`crate::AppSettings::TrailingVarArg`]
-    /// may be more appropriate.
-    ///
-    /// **NOTE:** Implicitly sets [`Arg::takes_value(true)`] [`Arg::multiple_values(true)`],
-    /// [`Arg::allow_hyphen_values(true)`], and [`Arg::last(true)`] when set to `true`.
-    ///
-    /// [`Arg::takes_value(true)`]: Arg::takes_value()
-    /// [`Arg::multiple_values(true)`]: Arg::multiple_values()
-    /// [`Arg::allow_hyphen_values(true)`]: Arg::allow_hyphen_values()
-    /// [`Arg::last(true)`]: Arg::last()
-    #[inline]
-    pub fn raw(self, yes: bool) -> Self {
-        self.takes_value(yes)
-            .multiple_values(yes)
-            .allow_hyphen_values(yes)
-            .last(yes)
-    }
-
-    /// Hides an argument from short help (`-h`).
-    ///
-    /// **NOTE:** This does **not** hide the argument from usage strings on error
-    ///
-    /// **NOTE:** Setting this option will cause next-line-help output style to be used
-    /// when long help (`--help`) is called.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// Arg::new("debug")
-    ///     .hide_short_help(true);
-    /// ```
-    ///
-    /// Setting `hide_short_help(true)` will hide the argument when displaying short help text
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .long("config")
-    ///         .hide_short_help(true)
-    ///         .help("Some help text describing the --config arg"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-h"
-    ///     ]);
-    /// ```
-    ///
-    /// The above example displays
-    ///
-    /// ```text
-    /// helptest
-    ///
-    /// USAGE:
-    ///    helptest [OPTIONS]
-    ///
-    /// OPTIONS:
-    /// -h, --help       Print help information
-    /// -V, --version    Print version information
-    /// ```
-    ///
-    /// However, when --help is called
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .long("config")
-    ///         .hide_short_help(true)
-    ///         .help("Some help text describing the --config arg"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--help"
-    ///     ]);
-    /// ```
-    ///
-    /// Then the following would be displayed
-    ///
-    /// ```text
-    /// helptest
-    ///
-    /// USAGE:
-    ///    helptest [OPTIONS]
-    ///
-    /// OPTIONS:
-    ///     --config     Some help text describing the --config arg
-    /// -h, --help       Print help information
-    /// -V, --version    Print version information
-    /// ```
-    #[inline]
-    pub fn hide_short_help(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::HiddenShortHelp)
-        } else {
-            self.unset_setting(ArgSettings::HiddenShortHelp)
-        }
-    }
-
     /// Deprecated, replaced with [`Arg::hide_short_help`]
     #[deprecated(since = "3.0.0", note = "Replaced with `Arg::hide_short_help`")]
     #[inline]
     pub fn hidden_short_help(self, yes: bool) -> Self {
         self.hide_short_help(yes)
-    }
-
-    /// Hides an argument from long help (`--help`).
-    ///
-    /// **NOTE:** This does **not** hide the argument from usage strings on error
-    ///
-    /// **NOTE:** Setting this option will cause next-line-help output style to be used
-    /// when long help (`--help`) is called.
-    ///
-    /// # Examples
-    ///
-    /// Setting `hide_long_help(true)` will hide the argument when displaying long help text
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .long("config")
-    ///         .hide_long_help(true)
-    ///         .help("Some help text describing the --config arg"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "--help"
-    ///     ]);
-    /// ```
-    ///
-    /// The above example displays
-    ///
-    /// ```text
-    /// helptest
-    ///
-    /// USAGE:
-    ///    helptest [OPTIONS]
-    ///
-    /// OPTIONS:
-    /// -h, --help       Print help information
-    /// -V, --version    Print version information
-    /// ```
-    ///
-    /// However, when -h is called
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    /// let m = App::new("prog")
-    ///     .arg(Arg::new("cfg")
-    ///         .long("config")
-    ///         .hide_long_help(true)
-    ///         .help("Some help text describing the --config arg"))
-    ///     .get_matches_from(vec![
-    ///         "prog", "-h"
-    ///     ]);
-    /// ```
-    ///
-    /// Then the following would be displayed
-    ///
-    /// ```text
-    /// helptest
-    ///
-    /// USAGE:
-    ///    helptest [OPTIONS]
-    ///
-    /// OPTIONS:
-    ///     --config     Some help text describing the --config arg
-    /// -h, --help       Print help information
-    /// -V, --version    Print version information
-    /// ```
-    #[inline]
-    pub fn hide_long_help(self, yes: bool) -> Self {
-        if yes {
-            self.setting(ArgSettings::HiddenLongHelp)
-        } else {
-            self.unset_setting(ArgSettings::HiddenLongHelp)
-        }
     }
 
     /// Deprecated, replaced with [`Arg::hide_long_help`]
@@ -4658,76 +4761,10 @@ impl<'help> Arg<'help> {
         self.hide_long_help(yes)
     }
 
-    /// Check if the [`ArgSettings`] variant is currently set on the argument.
-    ///
-    /// [`ArgSettings`]: crate::ArgSettings
-    #[inline]
-    pub fn is_set(&self, s: ArgSettings) -> bool {
-        self.settings.is_set(s)
-    }
-
-    /// Apply a setting to the argument.
-    ///
-    /// See [`ArgSettings`] for a full list of possibilities and examples.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{Arg, ArgSettings};
-    /// Arg::new("config")
-    ///     .setting(ArgSettings::Required)
-    ///     .setting(ArgSettings::TakesValue)
-    /// # ;
-    /// ```
-    ///
-    /// ```no_run
-    /// # use clap::{Arg, ArgSettings};
-    /// Arg::new("config")
-    ///     .setting(ArgSettings::Required | ArgSettings::TakesValue)
-    /// # ;
-    /// ```
-    #[inline]
-    pub fn setting<F>(mut self, setting: F) -> Self
-    where
-        F: Into<ArgFlags>,
-    {
-        self.settings.insert(setting.into());
-        self
-    }
-
     /// Deprecated, replaced with [`Arg::setting`]
     #[deprecated(since = "3.0.0", note = "Replaced with `Arg::setting`")]
     pub fn set(self, s: ArgSettings) -> Self {
         self.setting(s)
-    }
-
-    /// Remove a setting from the argument.
-    ///
-    /// See [`ArgSettings`] for a full list of possibilities and examples.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{Arg, ArgSettings};
-    /// Arg::new("config")
-    ///     .unset_setting(ArgSettings::Required)
-    ///     .unset_setting(ArgSettings::TakesValue)
-    /// # ;
-    /// ```
-    ///
-    /// ```no_run
-    /// # use clap::{Arg, ArgSettings};
-    /// Arg::new("config")
-    ///     .unset_setting(ArgSettings::Required | ArgSettings::TakesValue)
-    /// # ;
-    /// ```
-    #[inline]
-    pub fn unset_setting<F>(mut self, setting: F) -> Self
-    where
-        F: Into<ArgFlags>,
-    {
-        self.settings.remove(setting.into());
-        self
     }
 
     /// Deprecated, replaced with [`Arg::unset_setting`]
@@ -4735,53 +4772,10 @@ impl<'help> Arg<'help> {
     pub fn unset(self, s: ArgSettings) -> Self {
         self.unset_setting(s)
     }
+}
 
-    /// Override the [current] help section.
-    ///
-    /// [current]: crate::App::help_heading
-    #[inline]
-    pub fn help_heading<O>(mut self, heading: O) -> Self
-    where
-        O: Into<Option<&'help str>>,
-    {
-        self.help_heading = Some(heading.into());
-        self
-    }
-
-    /// Provide the shell a hint about how to complete this argument.
-    ///
-    /// See [`ValueHint`][crate::ValueHint] for more information.
-    ///
-    /// **NOTE:** implicitly sets [`Arg::takes_value(true)`].
-    ///
-    /// For example, to take a username as argument:
-    ///
-    /// ```
-    /// # use clap::{Arg, ValueHint};
-    /// Arg::new("user")
-    ///     .short('u')
-    ///     .long("user")
-    ///     .value_hint(ValueHint::Username);
-    /// ```
-    ///
-    /// To take a full command line and its arguments (for example, when writing a command wrapper):
-    ///
-    /// ```
-    /// # use clap::{App, AppSettings, Arg, ValueHint};
-    /// App::new("prog")
-    ///     .setting(AppSettings::TrailingVarArg)
-    ///     .arg(
-    ///         Arg::new("command")
-    ///             .takes_value(true)
-    ///             .multiple_values(true)
-    ///             .value_hint(ValueHint::CommandWithArguments)
-    ///     );
-    /// ```
-    pub fn value_hint(mut self, value_hint: ValueHint) -> Self {
-        self.value_hint = value_hint;
-        self.takes_value(true)
-    }
-
+// Internally used only
+impl<'help> Arg<'help> {
     pub(crate) fn _build(&mut self) {
         if self.is_positional() {
             self.settings.set(ArgSettings::TakesValue);
@@ -4803,6 +4797,11 @@ impl<'help> Arg<'help> {
                 self.num_vals = Some(val_names_len);
             }
         }
+    }
+
+    pub(crate) fn generated(mut self) -> Self {
+        self.provider = ArgProvider::Generated;
+        self
     }
 
     pub(crate) fn longest_filter(&self) -> bool {
@@ -4873,6 +4872,115 @@ impl<'help> PartialEq for Arg<'help> {
     }
 }
 
+impl<'help> PartialOrd for Arg<'help> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'help> Ord for Arg<'help> {
+    fn cmp(&self, other: &Arg) -> Ordering {
+        self.name.cmp(other.name)
+    }
+}
+
+impl<'help> Eq for Arg<'help> {}
+
+impl<'help> Display for Arg<'help> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        // Write the name such --long or -l
+        if let Some(l) = self.long {
+            write!(f, "--{}", l)?;
+        } else if let Some(s) = self.short {
+            write!(f, "-{}", s)?;
+        }
+        if !self.is_positional() && self.is_set(ArgSettings::TakesValue) {
+            let sep = if self.is_set(ArgSettings::RequireEquals) {
+                "="
+            } else {
+                " "
+            };
+            write!(f, "{}", sep)?;
+        }
+        if self.is_set(ArgSettings::TakesValue) || self.is_positional() {
+            display_arg_val(self, |s, _| write!(f, "{}", s))?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'help> fmt::Debug for Arg<'help> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        let mut ds = f.debug_struct("Arg");
+
+        #[allow(unused_mut)]
+        let mut ds = ds
+            .field("id", &self.id)
+            .field("provider", &self.provider)
+            .field("name", &self.name)
+            .field("help", &self.help)
+            .field("long_help", &self.long_help)
+            .field("blacklist", &self.blacklist)
+            .field("settings", &self.settings)
+            .field("overrides", &self.overrides)
+            .field("groups", &self.groups)
+            .field("requires", &self.requires)
+            .field("r_ifs", &self.r_ifs)
+            .field("r_unless", &self.r_unless)
+            .field("short", &self.short)
+            .field("long", &self.long)
+            .field("aliases", &self.aliases)
+            .field("short_aliases", &self.short_aliases)
+            .field("disp_ord", &self.disp_ord)
+            .field("possible_vals", &self.possible_vals)
+            .field("val_names", &self.val_names)
+            .field("num_vals", &self.num_vals)
+            .field("max_vals", &self.max_vals)
+            .field("min_vals", &self.min_vals)
+            .field(
+                "validator",
+                &self.validator.as_ref().map_or("None", |_| "Some(FnMut)"),
+            )
+            .field(
+                "validator_os",
+                &self.validator_os.as_ref().map_or("None", |_| "Some(FnMut)"),
+            )
+            .field("val_delim", &self.val_delim)
+            .field("default_vals", &self.default_vals)
+            .field("default_vals_ifs", &self.default_vals_ifs)
+            .field("terminator", &self.terminator)
+            .field("index", &self.index)
+            .field("help_heading", &self.help_heading)
+            .field("exclusive", &self.exclusive)
+            .field("value_hint", &self.value_hint)
+            .field("default_missing_vals", &self.default_missing_vals);
+
+        #[cfg(feature = "env")]
+        {
+            ds = ds.field("env", &self.env);
+        }
+
+        ds.finish()
+    }
+}
+
+type Validator<'a> = dyn FnMut(&str) -> Result<(), Box<dyn Error + Send + Sync>> + Send + 'a;
+type ValidatorOs<'a> = dyn FnMut(&OsStr) -> Result<(), Box<dyn Error + Send + Sync>> + Send + 'a;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) enum ArgProvider {
+    Generated,
+    GeneratedMutated,
+    User,
+}
+
+impl Default for ArgProvider {
+    fn default() -> Self {
+        ArgProvider::User
+    }
+}
+
 /// Write the values such as <name1> <name2>
 pub(crate) fn display_arg_val<F, T, E>(arg: &Arg, mut write: F) -> Result<(), E>
 where
@@ -4939,99 +5047,6 @@ where
         }
     }
     Ok(())
-}
-
-impl<'help> Display for Arg<'help> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        // Write the name such --long or -l
-        if let Some(l) = self.long {
-            write!(f, "--{}", l)?;
-        } else if let Some(s) = self.short {
-            write!(f, "-{}", s)?;
-        }
-        if !self.is_positional() && self.is_set(ArgSettings::TakesValue) {
-            let sep = if self.is_set(ArgSettings::RequireEquals) {
-                "="
-            } else {
-                " "
-            };
-            write!(f, "{}", sep)?;
-        }
-        if self.is_set(ArgSettings::TakesValue) || self.is_positional() {
-            display_arg_val(self, |s, _| write!(f, "{}", s))?;
-        }
-
-        Ok(())
-    }
-}
-
-impl<'help> PartialOrd for Arg<'help> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<'help> Ord for Arg<'help> {
-    fn cmp(&self, other: &Arg) -> Ordering {
-        self.name.cmp(other.name)
-    }
-}
-
-impl<'help> Eq for Arg<'help> {}
-
-impl<'help> fmt::Debug for Arg<'help> {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let mut ds = f.debug_struct("Arg");
-
-        #[allow(unused_mut)]
-        let mut ds = ds
-            .field("id", &self.id)
-            .field("provider", &self.provider)
-            .field("name", &self.name)
-            .field("help", &self.help)
-            .field("long_help", &self.long_help)
-            .field("blacklist", &self.blacklist)
-            .field("settings", &self.settings)
-            .field("overrides", &self.overrides)
-            .field("groups", &self.groups)
-            .field("requires", &self.requires)
-            .field("r_ifs", &self.r_ifs)
-            .field("r_unless", &self.r_unless)
-            .field("short", &self.short)
-            .field("long", &self.long)
-            .field("aliases", &self.aliases)
-            .field("short_aliases", &self.short_aliases)
-            .field("disp_ord", &self.disp_ord)
-            .field("possible_vals", &self.possible_vals)
-            .field("val_names", &self.val_names)
-            .field("num_vals", &self.num_vals)
-            .field("max_vals", &self.max_vals)
-            .field("min_vals", &self.min_vals)
-            .field(
-                "validator",
-                &self.validator.as_ref().map_or("None", |_| "Some(FnMut)"),
-            )
-            .field(
-                "validator_os",
-                &self.validator_os.as_ref().map_or("None", |_| "Some(FnMut)"),
-            )
-            .field("val_delim", &self.val_delim)
-            .field("default_vals", &self.default_vals)
-            .field("default_vals_ifs", &self.default_vals_ifs)
-            .field("terminator", &self.terminator)
-            .field("index", &self.index)
-            .field("help_heading", &self.help_heading)
-            .field("exclusive", &self.exclusive)
-            .field("value_hint", &self.value_hint)
-            .field("default_missing_vals", &self.default_missing_vals);
-
-        #[cfg(feature = "env")]
-        {
-            ds = ds.field("env", &self.env);
-        }
-
-        ds.finish()
-    }
 }
 
 // Flags

--- a/src/build/arg/possible_value.rs
+++ b/src/build/arg/possible_value.rs
@@ -32,80 +32,6 @@ pub struct PossibleValue<'help> {
     pub(crate) hide: bool,
 }
 
-impl<'help> From<&'help str> for PossibleValue<'help> {
-    fn from(s: &'help str) -> Self {
-        Self::new(s)
-    }
-}
-
-impl<'help> From<&'help &'help str> for PossibleValue<'help> {
-    fn from(s: &'help &'help str) -> Self {
-        Self::new(s)
-    }
-}
-
-/// Getters
-impl<'help> PossibleValue<'help> {
-    /// Get the name of the argument value
-    #[inline]
-    pub fn get_name(&self) -> &str {
-        self.name
-    }
-
-    /// Get the help specified for this argument, if any
-    #[inline]
-    pub fn get_help(&self) -> Option<&str> {
-        self.help
-    }
-
-    /// Should the value be hidden from help messages and completion
-    #[inline]
-    pub fn is_hidden(&self) -> bool {
-        self.hide
-    }
-
-    /// Get the name if argument value is not hidden, `None` otherwise
-    pub fn get_visible_name(&self) -> Option<&str> {
-        if self.hide {
-            None
-        } else {
-            Some(self.name)
-        }
-    }
-
-    /// Returns all valid values of the argument value.
-    ///
-    /// Namely the name and all aliases.
-    pub fn get_name_and_aliases(&self) -> impl Iterator<Item = &str> {
-        iter::once(&self.name).chain(&self.aliases).copied()
-    }
-
-    /// Tests if the value is valid for this argument value
-    ///
-    /// The value is valid if it is either the name or one of the aliases.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::PossibleValue;
-    /// let arg_value = PossibleValue::new("fast").alias("not-slow");
-    ///
-    /// assert!(arg_value.matches("fast", false));
-    /// assert!(arg_value.matches("not-slow", false));
-    ///
-    /// assert!(arg_value.matches("FAST", true));
-    /// assert!(!arg_value.matches("FAST", false));
-    /// ```
-    pub fn matches(&self, value: &str, ignore_case: bool) -> bool {
-        if ignore_case {
-            self.get_name_and_aliases()
-                .any(|name| eq_ignore_case(name, value))
-        } else {
-            self.get_name_and_aliases().any(|name| name == value)
-        }
-    }
-}
-
 impl<'help> PossibleValue<'help> {
     /// Create a [`PossibleValue`] with its name.
     ///
@@ -201,5 +127,79 @@ impl<'help> PossibleValue<'help> {
     {
         self.aliases.extend(names.into_iter());
         self
+    }
+}
+
+/// Reflection
+impl<'help> PossibleValue<'help> {
+    /// Get the name of the argument value
+    #[inline]
+    pub fn get_name(&self) -> &str {
+        self.name
+    }
+
+    /// Get the help specified for this argument, if any
+    #[inline]
+    pub fn get_help(&self) -> Option<&str> {
+        self.help
+    }
+
+    /// Should the value be hidden from help messages and completion
+    #[inline]
+    pub fn is_hidden(&self) -> bool {
+        self.hide
+    }
+
+    /// Get the name if argument value is not hidden, `None` otherwise
+    pub fn get_visible_name(&self) -> Option<&str> {
+        if self.hide {
+            None
+        } else {
+            Some(self.name)
+        }
+    }
+
+    /// Returns all valid values of the argument value.
+    ///
+    /// Namely the name and all aliases.
+    pub fn get_name_and_aliases(&self) -> impl Iterator<Item = &str> {
+        iter::once(&self.name).chain(&self.aliases).copied()
+    }
+
+    /// Tests if the value is valid for this argument value
+    ///
+    /// The value is valid if it is either the name or one of the aliases.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::PossibleValue;
+    /// let arg_value = PossibleValue::new("fast").alias("not-slow");
+    ///
+    /// assert!(arg_value.matches("fast", false));
+    /// assert!(arg_value.matches("not-slow", false));
+    ///
+    /// assert!(arg_value.matches("FAST", true));
+    /// assert!(!arg_value.matches("FAST", false));
+    /// ```
+    pub fn matches(&self, value: &str, ignore_case: bool) -> bool {
+        if ignore_case {
+            self.get_name_and_aliases()
+                .any(|name| eq_ignore_case(name, value))
+        } else {
+            self.get_name_and_aliases().any(|name| name == value)
+        }
+    }
+}
+
+impl<'help> From<&'help str> for PossibleValue<'help> {
+    fn from(s: &'help str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl<'help> From<&'help &'help str> for PossibleValue<'help> {
+    fn from(s: &'help &'help str) -> Self {
+        Self::new(s)
     }
 }

--- a/src/build/arg/regex.rs
+++ b/src/build/arg/regex.rs
@@ -23,22 +23,6 @@ impl<'a> RegexRef<'a> {
     }
 }
 
-impl<'a> FromStr for RegexRef<'a> {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Regex::from_str(s).map(|v| Self::Regex(Cow::Owned(v)))
-    }
-}
-
-impl<'a> TryFrom<&'a str> for RegexRef<'a> {
-    type Error = <Self as FromStr>::Err;
-
-    fn try_from(r: &'a str) -> Result<Self, Self::Error> {
-        Self::from_str(r)
-    }
-}
-
 impl<'a> From<&'a Regex> for RegexRef<'a> {
     fn from(r: &'a Regex) -> Self {
         Self::Regex(Cow::Borrowed(r))
@@ -60,6 +44,22 @@ impl<'a> From<&'a RegexSet> for RegexRef<'a> {
 impl<'a> From<RegexSet> for RegexRef<'a> {
     fn from(r: RegexSet) -> Self {
         Self::RegexSet(Cow::Owned(r))
+    }
+}
+
+impl<'a> TryFrom<&'a str> for RegexRef<'a> {
+    type Error = <Self as FromStr>::Err;
+
+    fn try_from(r: &'a str) -> Result<Self, Self::Error> {
+        Self::from_str(r)
+    }
+}
+
+impl<'a> FromStr for RegexRef<'a> {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Regex::from_str(s).map(|v| Self::Regex(Cow::Owned(v)))
     }
 }
 

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -4,37 +4,6 @@ use std::{ops::BitOr, str::FromStr};
 // Third party
 use bitflags::bitflags;
 
-bitflags! {
-    struct Flags: u32 {
-        const REQUIRED         = 1;
-        const MULTIPLE_OCC     = 1 << 1;
-        const NO_EMPTY_VALS    = 1 << 2;
-        const GLOBAL           = 1 << 3;
-        const HIDDEN           = 1 << 4;
-        const TAKES_VAL        = 1 << 5;
-        const USE_DELIM        = 1 << 6;
-        const NEXT_LINE_HELP   = 1 << 7;
-        const REQ_DELIM        = 1 << 9;
-        const DELIM_NOT_SET    = 1 << 10;
-        const HIDE_POS_VALS    = 1 << 11;
-        const ALLOW_TAC_VALS   = 1 << 12;
-        const REQUIRE_EQUALS   = 1 << 13;
-        const LAST             = 1 << 14;
-        const HIDE_DEFAULT_VAL = 1 << 15;
-        const CASE_INSENSITIVE = 1 << 16;
-        #[cfg(feature = "env")]
-        const HIDE_ENV_VALS    = 1 << 17;
-        const HIDDEN_SHORT_H   = 1 << 18;
-        const HIDDEN_LONG_H    = 1 << 19;
-        const MULTIPLE_VALS    = 1 << 20;
-        const MULTIPLE         = Self::MULTIPLE_OCC.bits | Self::MULTIPLE_VALS.bits;
-        #[cfg(feature = "env")]
-        const HIDE_ENV         = 1 << 21;
-        const UTF8_NONE        = 1 << 22;
-        const NO_OP            = 0;
-    }
-}
-
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ArgFlags(Flags);
@@ -43,36 +12,6 @@ impl Default for ArgFlags {
     fn default() -> Self {
         Self::empty()
     }
-}
-
-// @TODO @p6 @internal: Reorder alphabetically
-impl_settings! { ArgSettings, ArgFlags,
-    Required("required") => Flags::REQUIRED,
-    MultipleOccurrences("multipleoccurrences") => Flags::MULTIPLE_OCC,
-    MultipleValues("multiplevalues") => Flags::MULTIPLE_VALS,
-    Multiple("multiple") => Flags::MULTIPLE,
-    ForbidEmptyValues("forbidemptyvalues") => Flags::NO_EMPTY_VALS,
-    Global("global") => Flags::GLOBAL,
-    Hidden("hidden") => Flags::HIDDEN,
-    TakesValue("takesvalue") => Flags::TAKES_VAL,
-    UseValueDelimiter("usevaluedelimiter") => Flags::USE_DELIM,
-    NextLineHelp("nextlinehelp") => Flags::NEXT_LINE_HELP,
-    RequireDelimiter("requiredelimiter") => Flags::REQ_DELIM,
-    HidePossibleValues("hidepossiblevalues") => Flags::HIDE_POS_VALS,
-    AllowHyphenValues("allowhyphenvalues") => Flags::ALLOW_TAC_VALS,
-    AllowLeadingHyphen("allowleadinghypyhen") => Flags::ALLOW_TAC_VALS,
-    RequireEquals("requireequals") => Flags::REQUIRE_EQUALS,
-    Last("last") => Flags::LAST,
-    IgnoreCase("ignorecase") => Flags::CASE_INSENSITIVE,
-    CaseInsensitive("caseinsensitive") => Flags::CASE_INSENSITIVE,
-    #[cfg(feature = "env")]
-    HideEnv("hideenv") => Flags::HIDE_ENV,
-    #[cfg(feature = "env")]
-    HideEnvValues("hideenvvalues") => Flags::HIDE_ENV_VALS,
-    HideDefaultValue("hidedefaultvalue") => Flags::HIDE_DEFAULT_VAL,
-    HiddenShortHelp("hiddenshorthelp") => Flags::HIDDEN_SHORT_H,
-    HiddenLongHelp("hiddenlonghelp") => Flags::HIDDEN_LONG_H,
-    AllowInvalidUtf8("allowinvalidutf8") => Flags::UTF8_NONE
 }
 
 /// Various settings that apply to arguments and may be set, unset, and checked via getter/setter
@@ -148,6 +87,67 @@ pub enum ArgSettings {
     HiddenLongHelp,
     /// Specifies that option values that are invalid UTF-8 should *not* be treated as an error.
     AllowInvalidUtf8,
+}
+
+bitflags! {
+    struct Flags: u32 {
+        const REQUIRED         = 1;
+        const MULTIPLE_OCC     = 1 << 1;
+        const NO_EMPTY_VALS    = 1 << 2;
+        const GLOBAL           = 1 << 3;
+        const HIDDEN           = 1 << 4;
+        const TAKES_VAL        = 1 << 5;
+        const USE_DELIM        = 1 << 6;
+        const NEXT_LINE_HELP   = 1 << 7;
+        const REQ_DELIM        = 1 << 9;
+        const DELIM_NOT_SET    = 1 << 10;
+        const HIDE_POS_VALS    = 1 << 11;
+        const ALLOW_TAC_VALS   = 1 << 12;
+        const REQUIRE_EQUALS   = 1 << 13;
+        const LAST             = 1 << 14;
+        const HIDE_DEFAULT_VAL = 1 << 15;
+        const CASE_INSENSITIVE = 1 << 16;
+        #[cfg(feature = "env")]
+        const HIDE_ENV_VALS    = 1 << 17;
+        const HIDDEN_SHORT_H   = 1 << 18;
+        const HIDDEN_LONG_H    = 1 << 19;
+        const MULTIPLE_VALS    = 1 << 20;
+        const MULTIPLE         = Self::MULTIPLE_OCC.bits | Self::MULTIPLE_VALS.bits;
+        #[cfg(feature = "env")]
+        const HIDE_ENV         = 1 << 21;
+        const UTF8_NONE        = 1 << 22;
+        const NO_OP            = 0;
+    }
+}
+
+// @TODO @p6 @internal: Reorder alphabetically
+impl_settings! { ArgSettings, ArgFlags,
+    Required("required") => Flags::REQUIRED,
+    MultipleOccurrences("multipleoccurrences") => Flags::MULTIPLE_OCC,
+    MultipleValues("multiplevalues") => Flags::MULTIPLE_VALS,
+    Multiple("multiple") => Flags::MULTIPLE,
+    ForbidEmptyValues("forbidemptyvalues") => Flags::NO_EMPTY_VALS,
+    Global("global") => Flags::GLOBAL,
+    Hidden("hidden") => Flags::HIDDEN,
+    TakesValue("takesvalue") => Flags::TAKES_VAL,
+    UseValueDelimiter("usevaluedelimiter") => Flags::USE_DELIM,
+    NextLineHelp("nextlinehelp") => Flags::NEXT_LINE_HELP,
+    RequireDelimiter("requiredelimiter") => Flags::REQ_DELIM,
+    HidePossibleValues("hidepossiblevalues") => Flags::HIDE_POS_VALS,
+    AllowHyphenValues("allowhyphenvalues") => Flags::ALLOW_TAC_VALS,
+    AllowLeadingHyphen("allowleadinghypyhen") => Flags::ALLOW_TAC_VALS,
+    RequireEquals("requireequals") => Flags::REQUIRE_EQUALS,
+    Last("last") => Flags::LAST,
+    IgnoreCase("ignorecase") => Flags::CASE_INSENSITIVE,
+    CaseInsensitive("caseinsensitive") => Flags::CASE_INSENSITIVE,
+    #[cfg(feature = "env")]
+    HideEnv("hideenv") => Flags::HIDE_ENV,
+    #[cfg(feature = "env")]
+    HideEnvValues("hideenvvalues") => Flags::HIDE_ENV_VALS,
+    HideDefaultValue("hidedefaultvalue") => Flags::HIDE_DEFAULT_VAL,
+    HiddenShortHelp("hiddenshorthelp") => Flags::HIDDEN_SHORT_H,
+    HiddenLongHelp("hiddenlonghelp") => Flags::HIDDEN_LONG_H,
+    AllowInvalidUtf8("allowinvalidutf8") => Flags::UTF8_NONE
 }
 
 #[cfg(test)]

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -112,22 +112,6 @@ impl<'help> ArgGroup<'help> {
         ArgGroup::default().name(n)
     }
 
-    /// Deprecated, replaced with [`ArgGroup::new`]
-    #[deprecated(since = "3.0.0", note = "Replaced with `ArgGroup::new`")]
-    pub fn with_name<S: Into<&'help str>>(n: S) -> Self {
-        Self::new(n)
-    }
-
-    /// Deprecated in [Issue #9](https://github.com/epage/clapng/issues/9), maybe [`clap::Parser`][crate::Parser] would fit your use case?
-    #[cfg(feature = "yaml")]
-    #[deprecated(
-        since = "3.0.0",
-        note = "Maybe clap::Parser would fit your use case? (Issue #9)"
-    )]
-    pub fn from_yaml(yaml: &'help Yaml) -> Self {
-        Self::from(yaml)
-    }
-
     /// Sets the group name.
     ///
     /// # Examples
@@ -431,6 +415,22 @@ impl<'help> ArgGroup<'help> {
             self = self.conflicts_with(n);
         }
         self
+    }
+
+    /// Deprecated, replaced with [`ArgGroup::new`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `ArgGroup::new`")]
+    pub fn with_name<S: Into<&'help str>>(n: S) -> Self {
+        Self::new(n)
+    }
+
+    /// Deprecated in [Issue #9](https://github.com/epage/clapng/issues/9), maybe [`clap::Parser`][crate::Parser] would fit your use case?
+    #[cfg(feature = "yaml")]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Maybe clap::Parser would fit your use case? (Issue #9)"
+    )]
+    pub fn from_yaml(yaml: &'help Yaml) -> Self {
+        Self::from(yaml)
     }
 }
 

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -18,21 +18,6 @@ use crate::{
 use indexmap::IndexSet;
 use textwrap::core::display_width;
 
-pub(crate) fn dimensions() -> Option<(usize, usize)> {
-    #[cfg(not(feature = "wrap_help"))]
-    return None;
-
-    #[cfg(feature = "wrap_help")]
-    terminal_size::terminal_size().map(|(w, h)| (w.0.into(), h.0.into()))
-}
-
-const TAB: &str = "    ";
-
-pub(crate) enum HelpWriter<'writer> {
-    Normal(&'writer mut dyn Write),
-    Buffer(&'writer mut Colorizer),
-}
-
 /// `clap` Help Writer.
 ///
 /// Wraps a writer stream providing different methods to generate help for `clap` objects.
@@ -1005,6 +990,21 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
 
         Ok(())
     }
+}
+
+pub(crate) fn dimensions() -> Option<(usize, usize)> {
+    #[cfg(not(feature = "wrap_help"))]
+    return None;
+
+    #[cfg(feature = "wrap_help")]
+    terminal_size::terminal_size().map(|(w, h)| (w.0.into(), h.0.into()))
+}
+
+const TAB: &str = "    ";
+
+pub(crate) enum HelpWriter<'writer> {
+    Normal(&'writer mut dyn Write),
+    Buffer(&'writer mut Colorizer),
 }
 
 fn should_show_arg(use_long: bool, arg: &Arg) -> bool {

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -14,14 +14,6 @@ use indexmap::map::Entry;
 #[derive(Debug, Default)]
 pub(crate) struct ArgMatcher(pub(crate) ArgMatches);
 
-impl Deref for ArgMatcher {
-    type Target = ArgMatches;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 impl ArgMatcher {
     pub(crate) fn new(app: &App) -> Self {
         ArgMatcher(ArgMatches {
@@ -202,5 +194,13 @@ impl ArgMatcher {
             return o.is_set(ArgSettings::MultipleValues);
         }
         true
+    }
+}
+
+impl Deref for ArgMatcher {
+    type Target = ArgMatches;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -8,16 +8,6 @@ use std::{
 use crate::util::eq_ignore_case;
 use crate::INTERNAL_ERROR_MSG;
 
-// TODO: Maybe make this public?
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ValueType {
-    Unknown,
-    #[cfg(feature = "env")]
-    EnvVariable,
-    CommandLine,
-    DefaultValue,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MatchedArg {
     pub(crate) occurs: u64,
@@ -26,12 +16,6 @@ pub(crate) struct MatchedArg {
     vals: Vec<Vec<OsString>>,
     ignore_case: bool,
     invalid_utf8_allowed: Option<bool>,
-}
-
-impl Default for MatchedArg {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl MatchedArg {
@@ -153,6 +137,22 @@ impl MatchedArg {
     pub(crate) fn is_invalid_utf8_allowed(&self) -> Option<bool> {
         self.invalid_utf8_allowed
     }
+}
+
+impl Default for MatchedArg {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// TODO: Maybe make this public?
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ValueType {
+    Unknown,
+    #[cfg(feature = "env")]
+    EnvVariable,
+    CommandLine,
+    DefaultValue,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This contains two types of re-ordering:
- Internal, putting the focus of each file first.
- Public, re-arranging items and grouping impl blocks to try to better
  organize the documentation and find related items.

The main weakness of the docs work is in `Args`.  Its just a mess.  In
particular, we should probably link the simple casesm like `required` to
the advanced impl block.

Fixes #55